### PR TITLE
[codestyle] Fixed first letter casing in method names

### DIFF
--- a/Tests/BufferTest.php
+++ b/Tests/BufferTest.php
@@ -188,7 +188,7 @@ class BufferTest extends \PHPUnit_Framework_TestCase
 	 *
 	 * @return array
 	 */
-	public function casesEOF()
+	public function casesEof()
 	{
 		return array(
 			'~EOF' => array(
@@ -217,7 +217,7 @@ class BufferTest extends \PHPUnit_Framework_TestCase
 	 * @dataProvider casesEOF
 	 * @return void
 	 */
-	public function testStreamEOF($buffer, $name, $position, $expected)
+	public function testStreamEof($buffer, $name, $position, $expected)
 	{
 		$this->object->name = $name;
 		$this->object->position = $position;

--- a/Tests/BufferTest.php
+++ b/Tests/BufferTest.php
@@ -214,7 +214,7 @@ class BufferTest extends \PHPUnit_Framework_TestCase
 	 * @param   int     $position  The position in the buffer of the current pointer
 	 * @param   bool    $expected  The expected test return
 	 *
-	 * @dataProvider casesEOF
+	 * @dataProvider casesEof
 	 * @return void
 	 */
 	public function testStreamEof($buffer, $name, $position, $expected)


### PR DESCRIPTION
This PR fixes some more method names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Not touching casing of class names as this requires changes in casing in file names and causes issues at this point.