### PR TITLE
Fixes replacing of JPAH_ROOT if present somewhere in the middle of filename …

### DIFF
--- a/Tests/JStreamTest.php
+++ b/Tests/JStreamTest.php
@@ -18,6 +18,10 @@ class StreamTest extends PHPUnit_Framework_TestCase
 	 */
 	protected $object;
 
+	private $fileName = "FILE_NAME";
+	private $writePrefix = "WRITE_PREFIX";
+	private $readPrefix = "READ_PREFIX";
+
 	/**
 	 * Sets up the fixture, for example, opens a network connection.
 	 * This method is called before a test is executed.
@@ -28,7 +32,7 @@ class StreamTest extends PHPUnit_Framework_TestCase
 	{
 		parent::setUp();
 
-		$this->object = new Stream;
+		$this->object = new Stream($this->writePrefix, $this->readPrefix);
 	}
 
 	/**
@@ -423,17 +427,62 @@ class StreamTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Test...
-	 *
-	 * @todo Implement test_getFilename().
+	 * Test _getFilename method.
 	 *
 	 * @return void
 	 */
-	public function test_getFilename()
+	public function test_getFilenameBaseCase()
 	{
-		// Remove the following lines when you implement this test.
-		$this->markTestIncomplete(
-			'This test has not been implemented yet.'
+		$this->assertEquals(
+			$this->fileName,
+			$this->object->_getFilename($this->fileName, "w", false, true),
+			'Line:' . __LINE__ . ' _getFilename should return unmodified filename when use_prefix is false.'
+		);
+	}
+
+	/**
+	 * Test _getFilename method.
+	 *
+	 * @return void
+	 */
+	public function test_getFilenameUseOfReadAndWritePrefix()
+	{
+		$this->assertEquals(
+			$this->writePrefix . $this->fileName,
+			$this->object->_getFilename($this->fileName, "w", true, true),
+			'Line:' . __LINE__ . ' _getFilename should add write prefix if present.'
+		);
+
+		$this->assertEquals(
+			$this->readPrefix . $this->fileName,
+			$this->object->_getFilename($this->fileName, "r", true, true),
+			'Line:' . __LINE__ . ' _getFilename should add read prefix if present.'
+		);
+	}
+
+	/**
+	 * Test _getFilename method.
+	 *
+	 * @return void
+	 */
+	public function test_getFilenameReplaceJPATH_ROOTWithAbsoluteFilename()
+	{
+		$this->assertEquals(
+			$this->writePrefix . $this->fileName,
+			$this->object->_getFilename($this->fileName, "w", true, false),
+			'Line:' . __LINE__ . ' _getFilename should replace JPATH_ROOT and add write prefix if present.'
+		);
+
+		$this->assertEquals(
+			$this->readPrefix . '/Tests/' . $this->fileName,
+			$this->object->_getFilename(__DIR__ . '/' . $this->fileName, "r", true, false),
+			'Line:' . __LINE__ . ' _getFilename should replace JPATH_ROOT and add read prefix if present.'
+		);
+
+		$this->assertEquals(
+			$this->writePrefix . '/Tests/' . __DIR__ . '/' . $this->fileName,
+			$this->object->_getFilename(__DIR__ . '/' . __DIR__ . '/' . $this->fileName, "w", true, false),
+			'Line:' . __LINE__ . ' _getFilename should replace JPATH_ROOT from start only.'
 		);
 	}
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1375,25 +1375,27 @@ class Stream
 			$tmode = trim($mode, 'btf123456789');
 
 			// Check if it's a write mode then add the appropriate prefix
-			// Get rid of JPATH_ROOT (legacy compat) along the way
 			if (in_array($tmode, Helper::getWriteModes()))
 			{
-				if (!$relative && $this->writeprefix)
-				{
-					$filename = str_replace(JPATH_ROOT, '', $filename);
-				}
-
-				$filename = $this->writeprefix . $filename;
+				$prefixToUse = $this->writeprefix;
 			}
 			else
 			{
-				if (!$relative && $this->readprefix)
-				{
-					$filename = str_replace(JPATH_ROOT, '', $filename);
-				}
-
-				$filename = $this->readprefix . $filename;
+				$prefixToUse = $this->readprefix;
 			}
+
+			// Get rid of JPATH_ROOT (legacy compat)
+			if (!$relative && $prefixToUse)
+			{
+				$pos = strpos($filename, JPATH_ROOT);
+
+				if ($pos !== false)
+				{
+					$filename = substr_replace($filename, '', $pos, strlen(JPATH_ROOT));
+				}
+			}
+
+			$filename = ($prefixToUse ? $prefixToUse : '') . $filename;
 		}
 
 		return $filename;


### PR DESCRIPTION
…in JStream::_getFilename. Adding some tests for the same.

Solving issue https://github.com/joomla/joomla-cms/issues/7558 , will push same fix there too.