### PR TITLE
Fix https://github.com/joomla/joomla-cms/pull/8532

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -231,8 +231,8 @@ class Path
 
 		// Try to find a writable directory
 		$dir = is_writable('/tmp') ? '/tmp' : false;
-		$dir = (!$dir && is_writable($ssp)) ? $ssp : false;
-		$dir = (!$dir && is_writable($jtp)) ? $jtp : false;
+		$dir = (!$dir && is_writable($ssp)) ? $ssp : $dir;
+		$dir = (!$dir && is_writable($jtp)) ? $jtp : $dir;
 
 		if ($dir)
 		{


### PR DESCRIPTION
Currently it's impossible to have a directory as anything other than `JPATH_ROOT . '/tmp'` because the values of the previous directory checks are ignored.

For example say only the session tmp directory is writeable. checking `/tmp` returns false. `$ssp` is writeable so that directory is returned. Then you check `$jtp` which sees that `$dir` has string value so `!$dir` returns false leading to `$dir` being set to being false. Therefore the whole function returns false instead of performing the relevent function checks on the session directory.