### PR TITLE
[imp] Allow to append content to files and not always overwrite it by passing the required flag to file_put_contents

### DIFF
--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -402,6 +402,37 @@ class FileTest extends FilesystemTestCase
 	}
 
 	/**
+	 * Test write method when appending to a file.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 */
+	public function testWriteWithAppend()
+	{
+		$name = 'tempFile.txt';
+		$data = 'Lorem ipsum dolor sit amet';
+		$appendData = PHP_EOL . $data;
+
+		$this->assertTrue(
+			File::write($this->testPath . '/' . $name, $data),
+			'The file was not written.'
+		);
+
+		$this->assertTrue(
+			File::write($this->testPath . '/' . $name, $appendData, false, true),
+			'The file was not appended.'
+		);
+
+		$this->assertStringEqualsFile(
+			$this->testPath . '/' . $name,
+			$data . $appendData,
+			'The written file should match the given content.'
+		);
+	}
+
+	/**
 	 * Test write method.
 	 *
 	 * @return  void
@@ -549,38 +580,5 @@ class FileTest extends FilesystemTestCase
 		$this->assertTrue(
 			File::upload($this->testPath . '/' . $name . '.txt', $this->testPath . '/' . $name . '/' . $uploadedFileName)
 		);
-	}
-
-	/**
-	 * Test the new append mode in the write method.
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 *
-	 */
-	public function testWriteWithAppend()
-	{
-		$name = 'tempFile.txt';
-		$data = 'Lorem ipsum dolor sit amet';
-		$appendData = PHP_EOL . $data;
-
-		$this->assertTrue(
-			File::write($this->testPath . '/' . $name, $data),
-			'The file was not written.'
-		);
-
-		$this->assertTrue(
-			File::write($this->testPath . '/' . $name, $appendData, false, true),
-			'The file was not appended.'
-		);
-
-		$this->assertStringEqualsFile(
-			$this->testPath . '/' . $name,
-			$data . $appendData,
-			'The written file should match the given content.'
-		);
-
-		unlink($this->testPath . '/' . $name);
 	}
 }

--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -550,4 +550,37 @@ class FileTest extends FilesystemTestCase
 			File::upload($this->testPath . '/' . $name . '.txt', $this->testPath . '/' . $name . '/' . $uploadedFileName)
 		);
 	}
+
+	/**
+	 * Test the new append mode in the write method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 */
+	public function testWriteWithAppend()
+	{
+		$name = 'tempFile.txt';
+		$data = 'Lorem ipsum dolor sit amet';
+		$appendData = PHP_EOL . $data;
+
+		$this->assertTrue(
+			File::write($this->testPath . '/' . $name, $data),
+			'The file was not written.'
+		);
+
+		$this->assertTrue(
+			File::write($this->testPath . '/' . $name, $appendData, false, true),
+			'The file was not appended.'
+		);
+
+		$this->assertStringEqualsFile(
+			$this->testPath . '/' . $name,
+			$data . $appendData,
+			'The written file should match the given content.'
+		);
+
+		unlink($this->testPath . '/' . $name);
+	}
 }

--- a/Tests/StreamTest.php
+++ b/Tests/StreamTest.php
@@ -1093,6 +1093,42 @@ class StreamTest extends FilesystemTestCase
 	}
 
 	/**
+	 * Test write method when appending to a file.
+	 *
+	 * @return  void
+	 *
+	 * @requires PHP 5.4
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testwriteFileWithAppend()
+	{
+		$name = 'tempFile';
+		$path = vfsStream::url('root');
+		$filename = $path . '/' . $name;
+
+		$data = 'Lorem ipsum dolor sit amet';
+		$appendData = PHP_EOL . $data;
+
+		$this->assertTrue(
+			$this->object->writeFile($path . '/' . $name, $data),
+			'The file was not written.'
+		);
+
+		$this->assertTrue(
+			$this->object->writeFile($path . '/' . $name, $appendData, true),
+			'The file was not appended.'
+		);
+
+		$this->assertFileExists($path . '/' . $name);
+		$this->assertStringEqualsFile(
+			$path . '/' . $name,
+			$data . $appendData
+		);
+
+		unlink($path . '/' . $name);
+	}
+
+	/**
 	 * Test data for _getFilename test
 	 *
 	 * @return  void
@@ -1155,51 +1191,5 @@ class StreamTest extends FilesystemTestCase
 		$this->markTestIncomplete(
 			'This test has not been implemented yet.'
 		);
-	}
-
-	/**
-	 * Test the new append mode in the write method.
-	 *
-	 * @return  void
-	 *
-	 * @requires PHP 5.4
-	 * @since   __DEPLOY_VERSION__
-	 *
-	 */
-	public function testwriteFileWithAppend()
-	{
-		$name = 'tempFile.txt';
-		$path = vfsStream::url('root');
-		$data = 'Lorem ipsum dolor sit amet';
-		$appendData = PHP_EOL . $data;
-
-		$this->assertTrue(
-			$this->object->writeFile($path . '/' . $name, $data),
-			'The file was not written.'
-		);
-
-		$this->assertFileExists(
-			$path . '/' . $name,
-			'The file was not written.'
-		);
-
-		$this->assertStringEqualsFile(
-			$path . '/' . $name,
-			$data,
-			'The file was not written with the correct data.'
-		);
-
-		$this->assertTrue(
-			$this->object->writeFile($path . '/' . $name, $appendData, true),
-			'The content was not appended.'
-		);
-
-		$this->assertStringEqualsFile(
-			$path . '/' . $name,
-			$data . $appendData,
-			'The content was not appended correctly.'
-		);
-
-		unlink($path . '/' . $name);
 	}
 }

--- a/Tests/StreamTest.php
+++ b/Tests/StreamTest.php
@@ -1162,6 +1162,7 @@ class StreamTest extends FilesystemTestCase
 	 *
 	 * @return  void
 	 *
+	 * @requires PHP 5.4
 	 * @since   __DEPLOY_VERSION__
 	 *
 	 */

--- a/Tests/StreamTest.php
+++ b/Tests/StreamTest.php
@@ -1156,4 +1156,49 @@ class StreamTest extends FilesystemTestCase
 			'This test has not been implemented yet.'
 		);
 	}
+
+	/**
+	 * Test the new append mode in the write method.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 */
+	public function testwriteFileWithAppend()
+	{
+		$name = 'tempFile.txt';
+		$path = vfsStream::url('root');
+		$data = 'Lorem ipsum dolor sit amet';
+		$appendData = PHP_EOL . $data;
+
+		$this->assertTrue(
+			$this->object->writeFile($path . '/' . $name, $data),
+			'The file was not written.'
+		);
+
+		$this->assertFileExists(
+			$path . '/' . $name,
+			'The file was not written.'
+		);
+
+		$this->assertStringEqualsFile(
+			$path . '/' . $name,
+			$data,
+			'The file was not written with the correct data.'
+		);
+
+		$this->assertTrue(
+			$this->object->writeFile($path . '/' . $name, $appendData, true),
+			'The content was not appended.'
+		);
+
+		$this->assertStringEqualsFile(
+			$path . '/' . $name,
+			$data . $appendData,
+			'The content was not appended correctly.'
+		);
+
+		unlink($path . '/' . $name);
+	}
 }

--- a/src/File.php
+++ b/src/File.php
@@ -191,10 +191,10 @@ class File
 	/**
 	 * Write contents to a file
 	 *
-	 * @param   string   $file        The full file path
-	 * @param   string   $buffer      The buffer to write
-	 * @param   boolean  $useStreams  Use streams
-	 * @param   boolean  $appendOnly  Append to the file and not overwrite it.
+	 * @param   string   $file          The full file path
+	 * @param   string   $buffer        The buffer to write
+	 * @param   boolean  $useStreams    Use streams
+	 * @param   boolean  $appendToFile  Append to the file and not overwrite it.
 	 *
 	 * @return  boolean  True on success
 	 *
@@ -228,7 +228,7 @@ class File
 		{
 			return \is_int(file_put_contents($file, $buffer, FILE_APPEND));
 		}
-		
+
 		return \is_int(file_put_contents($file, $buffer));
 	}
 

--- a/src/File.php
+++ b/src/File.php
@@ -194,12 +194,13 @@ class File
 	 * @param   string   $file        The full file path
 	 * @param   string   $buffer      The buffer to write
 	 * @param   boolean  $useStreams  Use streams
+	 * @param   boolean  $appendOnly  Append to the file and not overwrite it.
 	 *
 	 * @return  boolean  True on success
 	 *
 	 * @since   1.0
 	 */
-	public static function write($file, &$buffer, $useStreams = false)
+	public static function write($file, &$buffer, $useStreams = false, $appendToFile = false)
 	{
 		@set_time_limit(ini_get('max_execution_time'));
 
@@ -223,7 +224,13 @@ class File
 
 		$file = Path::clean($file);
 
-		return \is_int(file_put_contents($file, $buffer));
+		// Set the reuired flag to only append to the file and not overwrite it
+		if ($appendToFile === true)
+		{
+			return \is_int(file_put_contents($file, $buffer, FILE_APPEND));
+		}
+		
+		return \is_int(file_put_contents($file, $buffer, ));
 	}
 
 	/**

--- a/src/File.php
+++ b/src/File.php
@@ -216,21 +216,20 @@ class File
 
 			// Beef up the chunk size to a meg
 			$stream->set('chunksize', (1024 * 1024));
-
-			$stream->writeFile($file, $buffer);
+			$stream->writeFile($file, $buffer, $appendToFile);
 
 			return true;
 		}
 
 		$file = Path::clean($file);
 
-		// Set the reuired flag to only append to the file and not overwrite it
+		// Set the required flag to only append to the file and not overwrite it
 		if ($appendToFile === true)
 		{
 			return \is_int(file_put_contents($file, $buffer, FILE_APPEND));
 		}
 		
-		return \is_int(file_put_contents($file, $buffer, ));
+		return \is_int(file_put_contents($file, $buffer));
 	}
 
 	/**

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1365,9 +1365,9 @@ class Stream
 	/**
 	 * Writes a chunk of data to a file.
 	 *
-	 * @param   string  $filename  The file name.
-	 * @param   string  $buffer    The data to write to the file.
-	 * @param   boolean  $appendOnly  Append to the file and not overwrite it.
+	 * @param   string   $filename      The file name.
+	 * @param   string   $buffer        The data to write to the file.
+	 * @param   boolean  $appendToFile  Append to the file and not overwrite it.
 	 *
 	 * @return  boolean
 	 *
@@ -1376,13 +1376,13 @@ class Stream
 	public function writeFile($filename, &$buffer, $appendToFile = false)
 	{
 		$fileMode = 'w';
-		
+
 		// Switch the filemode when we want to append to the file
 		if ($appendToFile)
 		{
 			$fileMode = 'a';
 		}
-		
+
 		if ($this->open($filename, $fileMode))
 		{
 			$result = $this->write($buffer);

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -1367,14 +1367,23 @@ class Stream
 	 *
 	 * @param   string  $filename  The file name.
 	 * @param   string  $buffer    The data to write to the file.
+	 * @param   boolean  $appendOnly  Append to the file and not overwrite it.
 	 *
 	 * @return  boolean
 	 *
 	 * @since   1.0
 	 */
-	public function writeFile($filename, &$buffer)
+	public function writeFile($filename, &$buffer, $appendToFile = false)
 	{
-		if ($this->open($filename, 'w'))
+		$fileMode = 'w';
+		
+		// Switch the filemode when we want to append to the file
+		if ($appendToFile)
+		{
+			$fileMode = 'a';
+		}
+		
+		if ($this->open($filename, $fileMode))
 		{
 			$result = $this->write($buffer);
 			$this->chmod();


### PR DESCRIPTION
### Summary of Changes

Allow to append content to files and not always overwrite it by passing the required flag to file_put_contents

### Testing Instructions

File::write($file, $buffer, $useStreams)) === File::write($file, $buffer, $useStreams, false)) => Works previous.

File::write($file, $buffer, $useStreams, true)) === File::write($file, $buffer, true, true)) => Buffer gets appended and the file is not overwritten. 

### Documentation Changes Required

API doc IIRC autogenerate from the doc block right?