### PR TITLE
Fixes Composer Deprecation warning: require-dev.mikey179/vfsStream is invalid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "joomla/coding-standards": "~2.0@alpha",
         "joomla/test": "~1.0",
-        "mikey179/vfsStream": "~1.0",
+        "mikey179/vfsstream": "~1.0",
         "paragonie/random_compat": "~1.0|~2.0",
         "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0"
     },


### PR DESCRIPTION
### Summary of Changes

Fixes the following warning issued by composer in the travis logs: 
`Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error.`
https://travis-ci.org/joomla-framework/filesystem/jobs/494582109

### Testing Instructions

No Composer warning any more

### Documentation Changes Required

n/a