### PR TITLE
Replace curly braces for PHP 7.4 compatibility

### DIFF
--- a/src/Clients/FtpClient.php
+++ b/src/Clients/FtpClient.php
@@ -1458,7 +1458,7 @@ class FtpClient
 
 				if (@preg_match($regexp, $file, $regs))
 				{
-					$fType = (int) strpos('-dl', $regs[1]{0});
+					$fType = (int) strpos('-dl', $regs[1][0]);
 
 					// $tmpArray['line'] = $regs[0];
 					$tmpArray['type']   = $fType;

--- a/src/Path.php
+++ b/src/Path.php
@@ -150,13 +150,13 @@ class Path
 		for ($i = 0; $i < 3; $i++)
 		{
 			// Read
-			$parsedMode .= ($mode{$i} & 04) ? 'r' : '-';
+			$parsedMode .= ($mode[$i] & 04) ? 'r' : '-';
 
 			// Write
-			$parsedMode .= ($mode{$i} & 02) ? 'w' : '-';
+			$parsedMode .= ($mode[$i] & 02) ? 'w' : '-';
 
 			// Execute
-			$parsedMode .= ($mode{$i} & 01) ? 'x' : '-';
+			$parsedMode .= ($mode[$i] & 01) ? 'x' : '-';
 		}
 
 		return $parsedMode;


### PR DESCRIPTION
### Summary of Changes

Replaces curly brackets used for array and string access with square brackets to solve deprecation warnings in PHP 7.4:

>Array and string offset access syntax with curly braces is deprecated

### Testing Instructions

Code review.

### Documentation Changes Required
No.