### PR TITLE
Add a "resolve" method to Path

### DIFF
--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -6,6 +6,7 @@
 
 namespace Joomla\Filesystem\Tests;
 
+use Joomla\Filesystem\Exception\FilesystemException;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Path;
 
@@ -360,6 +361,65 @@ class PathTest extends FilesystemTestCase
 		$this->assertEquals(
 			__FILE__,
 			Path::find(__DIR__, 'PathTest.php')
+		);
+	}
+
+	/**
+	 * Test resolve method
+	 *
+	 * @param   string  $path            test path
+	 * @param   string  $expectedResult  expected path
+	 *
+	 * @return  void
+	 *
+	 * @since   1.4.0
+	 *
+	 * @dataProvider  getResolveData
+	 */
+	public function testResolve($path, $expectedResult)
+	{
+		$this->assertEquals($expectedResult, Path::resolve($path));
+	}
+
+	/**
+	 * Description
+	 *
+	 * @expectedException         Joomla\Filesystem\Exception\FilesystemException
+	 * @expectedExceptionMessage  Path is outside of the defined root, path: [../var/www/joomla]
+	 *
+	 * @return void
+	 *
+	 * @since   1.4.0
+	 */
+	public function testResolveThrowsExceptionIfRootIsLeft()
+	{
+		Path::resolve("../var/www/joomla");
+	}
+
+	/**
+	 * Data provider for testResolve() method.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function getResolveData()
+	{
+		return array(
+			array("/var/www/joomla", "/var/www/joomla"),
+			array("C:/iis/www/joomla", "C:/iis/www/joomla"),
+			array("var/www/joomla", "var/www/joomla"),
+			array("./var/www/joomla", "var/www/joomla"),
+			array("/var/www/foo/../joomla", "/var/www/joomla"),
+			array("C:/var/www/foo/../joomla", "C:/var/www/joomla"),
+			array("/var/www/../foo/../joomla", "/var/joomla"),
+			array("C:/var/www/..foo../joomla", "C:/var/www/..foo../joomla"),
+			array("c:/var/www/..foo../joomla", "c:/var/www/..foo../joomla"),
+			array("/var/www///joomla", "/var/www/joomla"),
+			array("/var///www///joomla", "/var/www/joomla"),
+			array("C:/var///www///joomla", "C:/var/www/joomla"),
+			array("/var/\/../www///joomla", "/www/joomla"),
+			array("C:/var///www///joomla", "C:/var/www/joomla")
 		);
 	}
 }

--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -412,6 +412,7 @@ class PathTest extends FilesystemTestCase
 		return array(
 			array("/", "/"),
 			array("a", "a"),
+			array("/test/", "/test"),
 			array("C:/", "C:"),
 			array("/var/www/joomla", "/var/www/joomla"),
 			array("C:/iis/www/joomla", "C:/iis/www/joomla"),

--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -411,6 +411,7 @@ class PathTest extends FilesystemTestCase
 	{
 		return array(
 			array("/", "/"),
+			array("a", "a"),
 			array("C:/", "C:"),
 			array("/var/www/joomla", "/var/www/joomla"),
 			array("C:/iis/www/joomla", "C:/iis/www/joomla"),

--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -382,18 +382,22 @@ class PathTest extends FilesystemTestCase
 	}
 
 	/**
-	 * Description
+	 * Test resolve method
+
+	 * @param   string  $path            test path
 	 *
 	 * @expectedException         Joomla\Filesystem\Exception\FilesystemException
-	 * @expectedExceptionMessage  Path is outside of the defined root, path: [../var/www/joomla]
+	 * @expectedExceptionMessage  Path is outside of the defined root
 	 *
 	 * @return void
 	 *
 	 * @since   1.4.0
+	 *
+	 * @dataProvider  getResolveExceptionData
 	 */
-	public function testResolveThrowsExceptionIfRootIsLeft()
+	public function testResolveThrowsExceptionIfRootIsLeft($path)
 	{
-		Path::resolve("../var/www/joomla");
+		Path::resolve($path);
 	}
 
 	/**
@@ -421,6 +425,21 @@ class PathTest extends FilesystemTestCase
 			array("/var/\/../www///joomla", "/www/joomla"),
 			array("C:/var///www///joomla", "C:/var/www/joomla"),
 			array("/var\\www///joomla", "/var/www/joomla")
+		);
+	}
+
+	/**
+	 * Data provider for testResolve() method.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0
+	 */
+	public function getResolveExceptionData()
+	{
+		return array(
+			array("../var/www/joomla"),
+			array("/var/../../../www/joomla")
 		);
 	}
 }

--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -411,6 +411,7 @@ class PathTest extends FilesystemTestCase
 	{
 		return array(
 			array("/", "/"),
+			array("C:/", "C:"),
 			array("/var/www/joomla", "/var/www/joomla"),
 			array("C:/iis/www/joomla", "C:/iis/www/joomla"),
 			array("var/www/joomla", "var/www/joomla"),

--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -419,7 +419,8 @@ class PathTest extends FilesystemTestCase
 			array("/var///www///joomla", "/var/www/joomla"),
 			array("C:/var///www///joomla", "C:/var/www/joomla"),
 			array("/var/\/../www///joomla", "/www/joomla"),
-			array("C:/var///www///joomla", "C:/var/www/joomla")
+			array("C:/var///www///joomla", "C:/var/www/joomla"),
+			array("/var\\www///joomla", "/var/www/joomla")
 		);
 	}
 }

--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -410,6 +410,7 @@ class PathTest extends FilesystemTestCase
 	public function getResolveData()
 	{
 		return array(
+			array("/", "/"),
 			array("/var/www/joomla", "/var/www/joomla"),
 			array("C:/iis/www/joomla", "C:/iis/www/joomla"),
 			array("var/www/joomla", "var/www/joomla"),

--- a/Tests/PathTest.php
+++ b/Tests/PathTest.php
@@ -378,7 +378,7 @@ class PathTest extends FilesystemTestCase
 	 */
 	public function testResolve($path, $expectedResult)
 	{
-		$this->assertEquals($expectedResult, Path::resolve($path));
+		$this->assertEquals(str_replace("_DS_", DIRECTORY_SEPARATOR, $expectedResult), Path::resolve($path));
 	}
 
 	/**
@@ -410,25 +410,25 @@ class PathTest extends FilesystemTestCase
 	public function getResolveData()
 	{
 		return array(
-			array("/", "/"),
+			array("/", "_DS_"),
 			array("a", "a"),
-			array("/test/", "/test"),
+			array("/test/", "_DS_test"),
 			array("C:/", "C:"),
-			array("/var/www/joomla", "/var/www/joomla"),
-			array("C:/iis/www/joomla", "C:/iis/www/joomla"),
-			array("var/www/joomla", "var/www/joomla"),
-			array("./var/www/joomla", "var/www/joomla"),
-			array("/var/www/foo/../joomla", "/var/www/joomla"),
-			array("C:/var/www/foo/../joomla", "C:/var/www/joomla"),
-			array("/var/www/../foo/../joomla", "/var/joomla"),
-			array("C:/var/www/..foo../joomla", "C:/var/www/..foo../joomla"),
-			array("c:/var/www/..foo../joomla", "c:/var/www/..foo../joomla"),
-			array("/var/www///joomla", "/var/www/joomla"),
-			array("/var///www///joomla", "/var/www/joomla"),
-			array("C:/var///www///joomla", "C:/var/www/joomla"),
-			array("/var/\/../www///joomla", "/www/joomla"),
-			array("C:/var///www///joomla", "C:/var/www/joomla"),
-			array("/var\\www///joomla", "/var/www/joomla")
+			array("/var/www/joomla", "_DS_var_DS_www_DS_joomla"),
+			array("C:/iis/www/joomla", "C:_DS_iis_DS_www_DS_joomla"),
+			array("var/www/joomla", "var_DS_www_DS_joomla"),
+			array("./var/www/joomla", "var_DS_www_DS_joomla"),
+			array("/var/www/foo/../joomla", "_DS_var_DS_www_DS_joomla"),
+			array("C:/var/www/foo/../joomla", "C:_DS_var_DS_www_DS_joomla"),
+			array("/var/www/../foo/../joomla", "_DS_var_DS_joomla"),
+			array("C:/var/www/..foo../joomla", "C:_DS_var_DS_www_DS_..foo.._DS_joomla"),
+			array("c:/var/www/..foo../joomla", "c:_DS_var_DS_www_DS_..foo.._DS_joomla"),
+			array("/var/www///joomla", "_DS_var_DS_www_DS_joomla"),
+			array("/var///www///joomla", "_DS_var_DS_www_DS_joomla"),
+			array("C:/var///www///joomla", "C:_DS_var_DS_www_DS_joomla"),
+			array("/var/\/../www///joomla", "_DS_www_DS_joomla"),
+			array("C:/var///www///joomla", "C:_DS_var_DS_www_DS_joomla"),
+			array("/var\\www///joomla", "_DS_var_DS_www_DS_joomla")
 		);
 	}
 

--- a/src/Path.php
+++ b/src/Path.php
@@ -346,7 +346,7 @@ class Path
 	 *
 	 * @param   mixed   $path   A path to resolve
 	 *
-	 * @return  string   The resolved path
+	 * @return  string  The resolved path
 	 *
 	 * @since   1.0
 	 */

--- a/src/Path.php
+++ b/src/Path.php
@@ -353,7 +353,7 @@ class Path
 	 */
 	public static function resolve($path)
 	{
-		$path = self::clean($path);
+		$path = static::clean($path);
 
 		// Save start character for absolute path
 		$startCharacter = ($path[0] === DIRECTORY_SEPARATOR) ? DIRECTORY_SEPARATOR : '';

--- a/src/Path.php
+++ b/src/Path.php
@@ -340,4 +340,50 @@ class Path
 		// Could not find the file in the set of paths
 		return false;
 	}
+
+	/**
+	 * Resolves /./, /../ and multiple / in a string and returns the resulting absolute path, inspired by Flysystem
+	 *
+	 * @param   mixed   $path   A path to resolve
+	 *
+	 * @return  string   The resolved path
+	 *
+	 * @since   1.0
+	 */
+	public static function resolve($path)
+	{
+		$path = self::clean($path);
+
+		// Save start character for absolute path
+		$startCharacter = ($path[0] === DIRECTORY_SEPARATOR) ? DIRECTORY_SEPARATOR : '';
+
+		$parts = array();
+
+		foreach (explode('/', $path) as $part)
+		{
+			switch ($part)
+			{
+				case '':
+				case '.':
+					break;
+
+				case '..':
+					if (empty($parts))
+					{
+						throw new FilesystemException(
+							'Path is outside of the defined root, path: [' . $path . ']'
+						);
+					}
+
+					array_pop($parts);
+					break;
+
+				default:
+					$parts[] = $part;
+					break;
+			}
+		}
+
+		return $startCharacter . implode('/', $parts);
+	}
 }

--- a/src/Path.php
+++ b/src/Path.php
@@ -343,6 +343,7 @@ class Path
 
 	/**
 	 * Resolves /./, /../ and multiple / in a string and returns the resulting absolute path, inspired by Flysystem
+	 * Removes trailing slashes
 	 *
 	 * @param   mixed   $path   A path to resolve
 	 *

--- a/src/Path.php
+++ b/src/Path.php
@@ -349,7 +349,7 @@ class Path
 	 *
 	 * @return  string  The resolved path
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function resolve($path)
 	{

--- a/src/Path.php
+++ b/src/Path.php
@@ -360,7 +360,7 @@ class Path
 
 		$parts = array();
 
-		foreach (explode('/', $path) as $part)
+		foreach (explode(DIRECTORY_SEPARATOR, $path) as $part)
 		{
 			switch ($part)
 			{
@@ -383,6 +383,6 @@ class Path
 			}
 		}
 
-		return $startCharacter . implode('/', $parts);
+		return $startCharacter . implode(DIRECTORY_SEPARATOR, $parts);
 	}
 }

--- a/src/Path.php
+++ b/src/Path.php
@@ -345,7 +345,7 @@ class Path
 	 * Resolves /./, /../ and multiple / in a string and returns the resulting absolute path, inspired by Flysystem
 	 * Removes trailing slashes
 	 *
-	 * @param   mixed   $path   A path to resolve
+	 * @param   string   $path   A path to resolve
 	 *
 	 * @return  string  The resolved path
 	 *

--- a/src/Path.php
+++ b/src/Path.php
@@ -370,9 +370,7 @@ class Path
 				case '..':
 					if (empty($parts))
 					{
-						throw new FilesystemException(
-							'Path is outside of the defined root, path: [' . $path . ']'
-						);
+						throw new FilesystemException('Path is outside of the defined root');
 					}
 
 					array_pop($parts);


### PR DESCRIPTION
### Summary of Changes
I added a new "resolve" method to resolve relative paths without the need for the input path to be an absolute path in the first place. The path in question also doesn't need to exist beforehand, it's a virtual check.

This also allows a better fix for https://github.com/joomla/joomla-cms/issues/24539 that doesn't break symlinks.