### PR TITLE
[1.x] Phase out deprecated `$php_errormsg` variable and `track_errors` use

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -277,7 +277,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -332,6 +332,7 @@ class Stream
 		if (!$this->fh)
 		{
 			$error = error_get_last();
+
 			if ($error === null || $error['message'] === '')
 			{
 				// Error but nothing from php? Create our own
@@ -368,7 +369,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -448,7 +449,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -507,7 +508,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -570,7 +571,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -660,7 +661,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -763,7 +764,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -831,7 +832,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -931,7 +932,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -1019,7 +1020,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -1201,7 +1202,7 @@ class Stream
 			// Capture PHP errors
 			if (PHP_VERSION_ID < 70000)
 			{
-				// @Todo Remove this path, when PHP5 support is dropped. 
+				// @Todo Remove this path, when PHP5 support is dropped.
 				set_error_handler(
 					function () {
 						return false;
@@ -1260,7 +1261,7 @@ class Stream
 			// Capture PHP errors
 			if (PHP_VERSION_ID < 70000)
 			{
-				// @Todo Remove this path, when PHP5 support is dropped. 
+				// @Todo Remove this path, when PHP5 support is dropped.
 				set_error_handler(
 					function () {
 						return false;
@@ -1315,7 +1316,7 @@ class Stream
 			// Capture PHP errors
 			if (PHP_VERSION_ID < 70000)
 			{
-				// @Todo Remove this path, when PHP5 support is dropped. 
+				// @Todo Remove this path, when PHP5 support is dropped.
 				set_error_handler(
 					function () {
 						return false;
@@ -1366,7 +1367,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -1427,7 +1428,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -1500,7 +1501,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;
@@ -1572,7 +1573,7 @@ class Stream
 		// Capture PHP errors
 		if (PHP_VERSION_ID < 70000)
 		{
-			// @Todo Remove this path, when PHP5 support is dropped. 
+			// @Todo Remove this path, when PHP5 support is dropped.
 			set_error_handler(
 				function () {
 					return false;

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -275,9 +275,19 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = 'Error Unknown whilst opening a file';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		// Decide which context to use:
 		switch ($this->processingmethod)
@@ -316,12 +326,17 @@ class Stream
 				break;
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
-
 		if (!$this->fh)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => sprintf('Unknown error opening file %s', $filename)
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		// Return the result
@@ -347,9 +362,19 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = 'Error Unknown';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		switch ($this->processingmethod)
 		{
@@ -370,12 +395,17 @@ class Stream
 				break;
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
-
 		if (!$res)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to close stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		// Reset this
@@ -407,9 +437,19 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		switch ($this->processingmethod)
 		{
@@ -426,12 +466,11 @@ class Stream
 				break;
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
+		$error = error_get_last();
 
-		if ($php_errormsg)
+		if ($error !== null && $error['message'] !== '')
 		{
-			throw new FilesystemException($php_errormsg);
+			throw new FilesystemException($error['message']);
 		}
 
 		// Return the result
@@ -454,53 +493,42 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
+
 		$res = @filesize($this->filename);
 
-		if (!$res)
-		{
-			$tmpError = '';
-
-			if ($php_errormsg)
-			{
-				// Something went wrong.
-				// Store the error in case we need it.
-				$tmpError = $php_errormsg;
-			}
-
+		if (!$res) {
 			$res = Helper::remotefsize($this->filename);
+		}
 
-			if (!$res)
-			{
-				// Restore error tracking to what it was before.
-				ini_set('track_errors', $trackErrors);
-
-				if ($tmpError)
-				{
-					// Use the php_errormsg from before
-					throw new FilesystemException($tmpError);
-				}
-
-				// Error but nothing from php? How strange! Create our own
-				throw new FilesystemException('Failed to get file size. This may not work for all streams.');
+		if (!$res) {
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Failed to get file size. This may not work for all streams.'
+				);
 			}
 
-			$this->filesize = $res;
-			$retval         = $res;
-		}
-		else
-		{
-			$this->filesize = $res;
-			$retval         = $res;
+			throw new FilesystemException($error['message']);
 		}
 
-		// Restore error tracking to what it was before.
-		ini_set('track_errors', $trackErrors);
+		$this->filesize = $res;
 
 		// Return the result
-		return $retval;
+		return $this->filesize;
 	}
 
 	/**
@@ -521,9 +549,19 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = 'Error Unknown';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		switch ($this->processingmethod)
 		{
@@ -540,12 +578,17 @@ class Stream
 				break;
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
-
 		if (!$res)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to read from stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		// Return the result
@@ -591,9 +634,20 @@ class Stream
 		$retval = false;
 
 		// Capture PHP errors
-		$php_errormsg = 'Error Unknown';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
+
 		$remaining = $length;
 
 		do
@@ -620,10 +674,15 @@ class Stream
 
 			if (!$res)
 			{
-				// Restore error tracking to what it was before
-				ini_set('track_errors', $trackErrors);
+				$error = error_get_last();
+				if ($error === null || $error['message'] === '') {
+					// Error but nothing from php? Create our own
+					$error = array(
+						'message' => 'Unable to read from stream'
+					);
+				}
 
-				throw new FilesystemException($php_errormsg);
+				throw new FilesystemException($error['message']);
 			}
 
 			if (!$retval)
@@ -646,9 +705,6 @@ class Stream
 			}
 		}
 		while ($remaining || !$length);
-
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
 
 		// Return the result
 		return $retval;
@@ -676,9 +732,19 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		switch ($this->processingmethod)
 		{
@@ -695,13 +761,18 @@ class Stream
 				break;
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
-
 		// Seek, interestingly, returns 0 on success or -1 on failure.
 		if ($res == -1)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to seek in stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		// Return the result
@@ -724,9 +795,19 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		switch ($this->processingmethod)
 		{
@@ -743,13 +824,18 @@ class Stream
 				break;
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
-
 		// May return 0 so check if it's really false
 		if ($res === false)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to determine the current position in stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		// Return the result
@@ -804,9 +890,20 @@ class Stream
 		$retval = true;
 
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
+
 		$remaining = $length;
 		$start     = 0;
 
@@ -819,18 +916,19 @@ class Stream
 			// Returns false on error or the number of bytes written
 			if ($res === false)
 			{
-				// Restore error tracking to what it was before
-				ini_set('track_errors', $trackErrors);
+				$error = error_get_last();
+				if ($error === null || $error['message'] === '') {
+					// Error but nothing from php? Create our own
+					$error = array(
+						'message' => 'Unable to write to stream'
+					);
+				}
 
-				// Returned error
-				throw new FilesystemException($php_errormsg);
+				throw new FilesystemException($error['message']);
 			}
 
 			if ($res === 0)
 			{
-				// Restore error tracking to what it was before
-				ini_set('track_errors', $trackErrors);
-
 				// Wrote nothing?
 				throw new FilesystemException('Warning: No data written');
 			}
@@ -840,9 +938,6 @@ class Stream
 			$remaining -= $res;
 		}
 		while ($remaining);
-
-		// Restore error tracking to what it was before.
-		ini_set('track_errors', $trackErrors);
 
 		// Return the result
 		return $retval;
@@ -878,9 +973,20 @@ class Stream
 		}
 
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
+
 		$sch = parse_url($filename, \PHP_URL_SCHEME);
 
 		// Scheme specific options; ftp's chmod support is fun.
@@ -898,13 +1004,17 @@ class Stream
 				break;
 		}
 
-		// Restore error tracking to what it was before.
-		ini_set('track_errors', $trackErrors);
-
-		// Seek, interestingly, returns 0 on success or -1 on failure
 		if ($res === false)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to change mode of stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		// Return the result
@@ -1040,17 +1150,33 @@ class Stream
 		if ($this->fh)
 		{
 			// Capture PHP errors
-			$php_errormsg = 'Unknown error setting context option';
-			$trackErrors  = ini_get('track_errors');
-			ini_set('track_errors', true);
-			$retval = @stream_context_set_option($this->fh, $this->contextOptions);
+			if (PHP_VERSION_ID < 70000) {
+				// @Todo Remove this path, when PHP5 support is dropped. 
+				set_error_handler(
+					function () {
+						return false;
+					}
+				);
+				@trigger_error('');
+				restore_error_handler();
+			} else {
+				/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+				error_clear_last();
+			}
 
-			// Restore error tracking to what it was before
-			ini_set('track_errors', $trackErrors);
+			$retval = @stream_context_set_option($this->fh, $this->contextOptions);
 
 			if (!$retval)
 			{
-				throw new FilesystemException($php_errormsg);
+				$error = error_get_last();
+				if ($error === null || $error['message'] === '') {
+					// Error but nothing from php? Create our own
+					$error = array(
+						'message' => 'Unable to apply context to stream'
+					);
+				}
+
+				throw new FilesystemException($error['message']);
 			}
 		}
 
@@ -1078,18 +1204,29 @@ class Stream
 		if ($this->fh)
 		{
 			// Capture PHP errors
-			$php_errormsg = '';
-			$trackErrors  = ini_get('track_errors');
-			ini_set('track_errors', true);
+			if (PHP_VERSION_ID < 70000) {
+				// @Todo Remove this path, when PHP5 support is dropped. 
+				set_error_handler(
+					function () {
+						return false;
+					}
+				);
+				@trigger_error('');
+				restore_error_handler();
+			} else {
+				/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+				error_clear_last();
+			}
 
 			$res = @stream_filter_append($this->fh, $filtername, $readWrite, $params);
 
-			// Restore error tracking to what it was before.
-			ini_set('track_errors', $trackErrors);
-
-			if (!$res && $php_errormsg)
+			if (!$res)
 			{
-				throw new FilesystemException($php_errormsg);
+				$error = error_get_last();
+
+				if ($error !== null && $error['message'] !== '') {
+					throw new FilesystemException($error['message']);
+				}
 			}
 
 			$this->filters[] = &$res;
@@ -1118,18 +1255,28 @@ class Stream
 		if ($this->fh)
 		{
 			// Capture PHP errors
-			$php_errormsg = '';
-			$trackErrors  = ini_get('track_errors');
-			ini_set('track_errors', true);
+			if (PHP_VERSION_ID < 70000) {
+				// @Todo Remove this path, when PHP5 support is dropped. 
+				set_error_handler(
+					function () {
+						return false;
+					}
+				);
+				@trigger_error('');
+				restore_error_handler();
+			} else {
+				/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+				error_clear_last();
+			}
+
 			$res = @stream_filter_prepend($this->fh, $filtername, $readWrite, $params);
 
-			// Restore error tracking to what it was before.
-			ini_set('track_errors', $trackErrors);
+			if (!$res) {
+				$error = error_get_last();
 
-			if (!$res && $php_errormsg)
-			{
-				// Set the error msg
-				throw new FilesystemException($php_errormsg);
+				if ($error !== null && $error['message'] !== '') {
+					throw new FilesystemException($error['message']);
+				}
 			}
 
 			array_unshift($this->filters, '');
@@ -1154,9 +1301,19 @@ class Stream
 	public function removeFilter(&$resource, $byindex = false)
 	{
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		if ($byindex)
 		{
@@ -1167,12 +1324,17 @@ class Stream
 			$res = stream_filter_remove($resource);
 		}
 
-		// Restore error tracking to what it was before.
-		ini_set('track_errors', $trackErrors);
-
 		if (!$res)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to remove filter from stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		return $res;
@@ -1195,8 +1357,19 @@ class Stream
 	public function copy($src, $dest, $context = null, $usePrefix = true, $relative = false)
 	{
 		// Capture PHP errors
-		$trackErrors = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		$chmodDest = $this->_getFilename($dest, 'w', $usePrefix, $relative);
 
@@ -1222,12 +1395,12 @@ class Stream
 			$res = @copy($src, $dest);
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
+		if (!$res) {
+			$error = error_get_last();
 
-		if (!$res && $php_errormsg)
-		{
-			throw new FilesystemException($php_errormsg);
+			if ($error !== null && $error['message'] !== '') {
+				throw new FilesystemException($error['message']);
+			}
 		}
 
 		$this->chmod($chmodDest);
@@ -1252,9 +1425,19 @@ class Stream
 	public function move($src, $dest, $context = null, $usePrefix = true, $relative = false)
 	{
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		$src  = $this->_getFilename($src, 'w', $usePrefix, $relative);
 		$dest = $this->_getFilename($dest, 'w', $usePrefix, $relative);
@@ -1275,12 +1458,17 @@ class Stream
 			$res = @rename($src, $dest);
 		}
 
-		// Restore error tracking to what it was before
-		ini_set('track_errors', $trackErrors);
-
 		if (!$res)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to move stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		$this->chmod($dest);
@@ -1304,9 +1492,19 @@ class Stream
 	public function delete($filename, $context = null, $usePrefix = true, $relative = false)
 	{
 		// Capture PHP errors
-		$php_errormsg = '';
-		$trackErrors  = ini_get('track_errors');
-		ini_set('track_errors', true);
+		if (PHP_VERSION_ID < 70000) {
+			// @Todo Remove this path, when PHP5 support is dropped. 
+			set_error_handler(
+				function () {
+					return false;
+				}
+			);
+			@trigger_error('');
+			restore_error_handler();
+		} else {
+			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+			error_clear_last();
+		}
 
 		$filename = $this->_getFilename($filename, 'w', $usePrefix, $relative);
 
@@ -1326,12 +1524,17 @@ class Stream
 			$res = @unlink($filename);
 		}
 
-		// Restore error tracking to what it was before.
-		ini_set('track_errors', $trackErrors);
-
 		if (!$res)
 		{
-			throw new FilesystemException($php_errormsg);
+			$error = error_get_last();
+			if ($error === null || $error['message'] === '') {
+				// Error but nothing from php? Create our own
+				$error = array(
+					'message' => 'Unable to delete stream'
+				);
+			}
+
+			throw new FilesystemException($error['message']);
 		}
 
 		return $res;

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -275,7 +275,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -284,7 +285,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -329,7 +332,8 @@ class Stream
 		if (!$this->fh)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => sprintf('Unknown error opening file %s', $filename)
@@ -362,7 +366,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -371,7 +376,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -398,7 +405,9 @@ class Stream
 		if (!$res)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to close stream'
@@ -437,7 +446,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -446,7 +456,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -493,7 +505,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -502,20 +515,26 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
 
 		$res = @filesize($this->filename);
 
-		if (!$res) {
+		if (!$res)
+		{
 			$res = Helper::remotefsize($this->filename);
 		}
 
-		if (!$res) {
+		if (!$res)
+		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Failed to get file size. This may not work for all streams.'
@@ -549,7 +568,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -558,7 +578,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -581,7 +603,9 @@ class Stream
 		if (!$res)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to read from stream'
@@ -634,7 +658,8 @@ class Stream
 		$retval = false;
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -643,7 +668,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -675,7 +702,9 @@ class Stream
 			if (!$res)
 			{
 				$error = error_get_last();
-				if ($error === null || $error['message'] === '') {
+
+				if ($error === null || $error['message'] === '')
+				{
 					// Error but nothing from php? Create our own
 					$error = array(
 						'message' => 'Unable to read from stream'
@@ -732,7 +761,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -741,7 +771,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -765,7 +797,9 @@ class Stream
 		if ($res == -1)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to seek in stream'
@@ -795,7 +829,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -804,7 +839,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -828,7 +865,9 @@ class Stream
 		if ($res === false)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to determine the current position in stream'
@@ -890,7 +929,8 @@ class Stream
 		$retval = true;
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -899,7 +939,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -917,7 +959,9 @@ class Stream
 			if ($res === false)
 			{
 				$error = error_get_last();
-				if ($error === null || $error['message'] === '') {
+
+				if ($error === null || $error['message'] === '')
+				{
 					// Error but nothing from php? Create our own
 					$error = array(
 						'message' => 'Unable to write to stream'
@@ -973,7 +1017,8 @@ class Stream
 		}
 
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -982,7 +1027,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -1007,7 +1054,9 @@ class Stream
 		if ($res === false)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to change mode of stream'
@@ -1150,7 +1199,8 @@ class Stream
 		if ($this->fh)
 		{
 			// Capture PHP errors
-			if (PHP_VERSION_ID < 70000) {
+			if (PHP_VERSION_ID < 70000)
+			{
 				// @Todo Remove this path, when PHP5 support is dropped. 
 				set_error_handler(
 					function () {
@@ -1159,7 +1209,9 @@ class Stream
 				);
 				@trigger_error('');
 				restore_error_handler();
-			} else {
+			}
+			else
+			{
 				/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 				error_clear_last();
 			}
@@ -1169,7 +1221,9 @@ class Stream
 			if (!$retval)
 			{
 				$error = error_get_last();
-				if ($error === null || $error['message'] === '') {
+
+				if ($error === null || $error['message'] === '')
+				{
 					// Error but nothing from php? Create our own
 					$error = array(
 						'message' => 'Unable to apply context to stream'
@@ -1204,7 +1258,8 @@ class Stream
 		if ($this->fh)
 		{
 			// Capture PHP errors
-			if (PHP_VERSION_ID < 70000) {
+			if (PHP_VERSION_ID < 70000)
+			{
 				// @Todo Remove this path, when PHP5 support is dropped. 
 				set_error_handler(
 					function () {
@@ -1213,7 +1268,9 @@ class Stream
 				);
 				@trigger_error('');
 				restore_error_handler();
-			} else {
+			}
+			else
+			{
 				/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 				error_clear_last();
 			}
@@ -1224,7 +1281,8 @@ class Stream
 			{
 				$error = error_get_last();
 
-				if ($error !== null && $error['message'] !== '') {
+				if ($error !== null && $error['message'] !== '')
+				{
 					throw new FilesystemException($error['message']);
 				}
 			}
@@ -1255,7 +1313,8 @@ class Stream
 		if ($this->fh)
 		{
 			// Capture PHP errors
-			if (PHP_VERSION_ID < 70000) {
+			if (PHP_VERSION_ID < 70000)
+			{
 				// @Todo Remove this path, when PHP5 support is dropped. 
 				set_error_handler(
 					function () {
@@ -1264,17 +1323,21 @@ class Stream
 				);
 				@trigger_error('');
 				restore_error_handler();
-			} else {
+			}
+			else
+			{
 				/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 				error_clear_last();
 			}
 
 			$res = @stream_filter_prepend($this->fh, $filtername, $readWrite, $params);
 
-			if (!$res) {
+			if (!$res)
+			{
 				$error = error_get_last();
 
-				if ($error !== null && $error['message'] !== '') {
+				if ($error !== null && $error['message'] !== '')
+				{
 					throw new FilesystemException($error['message']);
 				}
 			}
@@ -1301,7 +1364,8 @@ class Stream
 	public function removeFilter(&$resource, $byindex = false)
 	{
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -1310,7 +1374,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -1327,7 +1393,9 @@ class Stream
 		if (!$res)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to remove filter from stream'
@@ -1357,7 +1425,8 @@ class Stream
 	public function copy($src, $dest, $context = null, $usePrefix = true, $relative = false)
 	{
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -1366,7 +1435,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -1395,10 +1466,12 @@ class Stream
 			$res = @copy($src, $dest);
 		}
 
-		if (!$res) {
+		if (!$res)
+		{
 			$error = error_get_last();
 
-			if ($error !== null && $error['message'] !== '') {
+			if ($error !== null && $error['message'] !== '')
+			{
 				throw new FilesystemException($error['message']);
 			}
 		}
@@ -1425,7 +1498,8 @@ class Stream
 	public function move($src, $dest, $context = null, $usePrefix = true, $relative = false)
 	{
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -1434,7 +1508,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -1461,7 +1537,9 @@ class Stream
 		if (!$res)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to move stream'
@@ -1492,7 +1570,8 @@ class Stream
 	public function delete($filename, $context = null, $usePrefix = true, $relative = false)
 	{
 		// Capture PHP errors
-		if (PHP_VERSION_ID < 70000) {
+		if (PHP_VERSION_ID < 70000)
+		{
 			// @Todo Remove this path, when PHP5 support is dropped. 
 			set_error_handler(
 				function () {
@@ -1501,7 +1580,9 @@ class Stream
 			);
 			@trigger_error('');
 			restore_error_handler();
-		} else {
+		}
+		else
+		{
 			/** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
 			error_clear_last();
 		}
@@ -1527,7 +1608,9 @@ class Stream
 		if (!$res)
 		{
 			$error = error_get_last();
-			if ($error === null || $error['message'] === '') {
+
+			if ($error === null || $error['message'] === '')
+			{
 				// Error but nothing from php? Create our own
 				$error = array(
 					'message' => 'Unable to delete stream'


### PR DESCRIPTION
### Summary of Changes

PHP 7.2 deprecates the track_errors INI configuration and the scoped $php_errormsg variable in favor of using the error_get_last() function for retrieving error data, and at PHP 7.0 using error_clear_last() to clear any errors (to my knowledge we aren't doing anything in core requiring the latter at the moment).

This PR phases out this deprecated functionality.

### Testing Instructions

The packages should still function normally, including error handling (easiest way to test error handling is enable debug mode and language debug and break one of the language files with a parsing error).
