### PR TITLE
Propose Opcache invalidation on file operations

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -318,7 +318,7 @@ class File
 		{
 			$info = pathinfo($file);
 
-			if ($info['extension'] === 'php')
+			if (isset($info['extension']) && $info['extension'] === 'php')
 			{
 				// Force invalidation to be absolutely sure the opcache is cleared for this file.
 				opcache_invalidate($file, true);

--- a/src/File.php
+++ b/src/File.php
@@ -91,6 +91,8 @@ class File
 				throw new FilesystemException(sprintf('%1$s(%2$s, %3$s): %4$s', __METHOD__, $src, $dest, $stream->getError()));
 			}
 
+			self::invalidateOpcache($dest);
+
 			return true;
 		}
 
@@ -98,6 +100,8 @@ class File
 		{
 			throw new FilesystemException(__METHOD__ . ': Copy failed.');
 		}
+
+		self::invalidateOpcache($dest);
 
 		return true;
 	}
@@ -136,6 +140,8 @@ class File
 			{
 				throw new FilesystemException(__METHOD__ . ': Failed deleting ' . $filename);
 			}
+
+			self::invalidateOpcache($file);
 		}
 
 		return true;
@@ -177,6 +183,8 @@ class File
 				throw new FilesystemException(__METHOD__ . ': ' . $stream->getError());
 			}
 
+			self::invalidateOpcache($dest);
+
 			return true;
 		}
 
@@ -184,6 +192,8 @@ class File
 		{
 			throw new FilesystemException(__METHOD__ . ': Rename failed.');
 		}
+
+		self::invalidateOpcache($dest);
 
 		return true;
 	}
@@ -218,6 +228,8 @@ class File
 			$stream->set('chunksize', (1024 * 1024));
 			$stream->writeFile($file, $buffer, $appendToFile);
 
+			self::invalidateOpcache($file);
+
 			return true;
 		}
 
@@ -226,10 +238,16 @@ class File
 		// Set the required flag to only append to the file and not overwrite it
 		if ($appendToFile === true)
 		{
-			return \is_int(file_put_contents($file, $buffer, \FILE_APPEND));
+			$res = \is_int(file_put_contents($file, $buffer, \FILE_APPEND));
+		}
+		else
+		{
+			$res = \is_int(file_put_contents($file, $buffer));
 		}
 
-		return \is_int(file_put_contents($file, $buffer));
+		self::invalidateOpcache($file);
+
+		return $res;
 	}
 
 	/**
@@ -266,6 +284,8 @@ class File
 				throw new FilesystemException(sprintf('%1$s(%2$s, %3$s): %4$s', __METHOD__, $src, $dest, $stream->getError()));
 			}
 
+			self::invalidateOpcache($dest);
+
 			return true;
 		}
 
@@ -274,6 +294,8 @@ class File
 			// Short circuit to prevent file permission errors
 			if (Path::setPermissions($dest))
 			{
+				self::invalidateOpcache($dest);
+
 				return true;
 			}
 
@@ -281,5 +303,26 @@ class File
 		}
 
 		throw new FilesystemException(__METHOD__ . ': Failed to move file.');
+	}
+
+	/**
+	 * Invalidate any opcache for a newly written file immediately, if opcache* functions exist and if this was a PHP file.
+	 *
+	 * @param   string  $file  The path to the file just written to, to flush from opcache
+	 *
+	 * @return void
+	 */
+	public static function invalidateOpcache($file)
+	{
+		if (function_exists('opcache_invalidate'))
+		{
+			$info = pathinfo($file);
+
+			if ($info['extension'] === 'php')
+			{
+				// Force invalidation to be absolutely sure the opcache is cleared for this file.
+				opcache_invalidate($file, true);
+			}
+		}
 	}
 }

--- a/src/File.php
+++ b/src/File.php
@@ -91,7 +91,7 @@ class File
 				throw new FilesystemException(sprintf('%1$s(%2$s, %3$s): %4$s', __METHOD__, $src, $dest, $stream->getError()));
 			}
 
-			self::invalidateOpcache($dest);
+			self::invalidateFileCache($dest);
 
 			return true;
 		}
@@ -101,7 +101,7 @@ class File
 			throw new FilesystemException(__METHOD__ . ': Copy failed.');
 		}
 
-		self::invalidateOpcache($dest);
+		self::invalidateFileCache($dest);
 
 		return true;
 	}
@@ -141,7 +141,7 @@ class File
 				throw new FilesystemException(__METHOD__ . ': Failed deleting ' . $filename);
 			}
 
-			self::invalidateOpcache($file);
+			self::invalidateFileCache($file);
 		}
 
 		return true;
@@ -183,7 +183,7 @@ class File
 				throw new FilesystemException(__METHOD__ . ': ' . $stream->getError());
 			}
 
-			self::invalidateOpcache($dest);
+			self::invalidateFileCache($dest);
 
 			return true;
 		}
@@ -193,7 +193,7 @@ class File
 			throw new FilesystemException(__METHOD__ . ': Rename failed.');
 		}
 
-		self::invalidateOpcache($dest);
+		self::invalidateFileCache($dest);
 
 		return true;
 	}
@@ -228,7 +228,7 @@ class File
 			$stream->set('chunksize', (1024 * 1024));
 			$stream->writeFile($file, $buffer, $appendToFile);
 
-			self::invalidateOpcache($file);
+			self::invalidateFileCache($file);
 
 			return true;
 		}
@@ -245,7 +245,7 @@ class File
 			$res = \is_int(file_put_contents($file, $buffer));
 		}
 
-		self::invalidateOpcache($file);
+		self::invalidateFileCache($file);
 
 		return $res;
 	}
@@ -284,7 +284,7 @@ class File
 				throw new FilesystemException(sprintf('%1$s(%2$s, %3$s): %4$s', __METHOD__, $src, $dest, $stream->getError()));
 			}
 
-			self::invalidateOpcache($dest);
+			self::invalidateFileCache($dest);
 
 			return true;
 		}
@@ -294,7 +294,7 @@ class File
 			// Short circuit to prevent file permission errors
 			if (Path::setPermissions($dest))
 			{
-				self::invalidateOpcache($dest);
+				self::invalidateFileCache($dest);
 
 				return true;
 			}
@@ -312,7 +312,7 @@ class File
 	 *
 	 * @return void
 	 */
-	public static function invalidateOpcache($file)
+	public static function invalidateFileCache($file)
 	{
 		if (function_exists('opcache_invalidate'))
 		{


### PR DESCRIPTION
### Summary of Changes

On write or delete of a file, invalidate the opcache for that file, so that changes are loaded into memory on servers with opcache caching set to maximum, or incorrect configured, or set to preload/never revalidate.

### Testing Instructions

everything should work as before. 

If you really want to test then install php with opcache preload and revalidate timestamps set to never, and use an opcache gun to view what's in the cache, make a change to a file using this class, and compare what is in the cache after. 

### Documentation Changes Required
none

### Why/History

Experience: https://github.com/joomla/joomla-cms/issues/32592
Joomla 3 https://github.com/joomla/joomla-cms/pull/32918
Joomla 4 https://github.com/joomla/joomla-cms/pull/32915