### PR TITLE
Improve changes to invalidating opcache

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -144,7 +144,7 @@ class File
 			self::invalidateFileCache($file);
 
 			/**
-			 * In case of restricted permissions we zap it one way or the other
+			 * In case of restricted permissions we delete it one way or the other
 			 * as long as the owner is either the webserver or the ftp
 			 */
 			if (!@ unlink($file))

--- a/src/File.php
+++ b/src/File.php
@@ -130,18 +130,27 @@ class File
 				throw new FilesystemException(__METHOD__ . ': Failed deleting inaccessible file ' . $filename);
 			}
 
-			// Try making the file writable first. If it's read-only, it can't be deleted
-			// on Windows, even if the parent folder is writable
+			/**
+			 * Try making the file writable first. If it's read-only, it can't be deleted
+			 * on Windows, even if the parent folder is writable
+			 */
 			@chmod($file, 0777);
 
-			// In case of restricted permissions we zap it one way or the other
-			// as long as the owner is either the webserver or the ftp
+			/**
+			 * Invalidate the OPCache for the file before actually deleting it
+			 * @see https://github.com/joomla/joomla-cms/pull/32915#issuecomment-812865635
+			 * @see https://www.php.net/manual/en/function.opcache-invalidate.php#116372
+			 */
+			self::invalidateFileCache($file);
+
+			/**
+			 * In case of restricted permissions we zap it one way or the other
+			 * as long as the owner is either the webserver or the ftp
+			 */
 			if (!@ unlink($file))
 			{
 				throw new FilesystemException(__METHOD__ . ': Failed deleting ' . $filename);
 			}
-
-			self::invalidateFileCache($file);
 		}
 
 		return true;

--- a/src/File.php
+++ b/src/File.php
@@ -189,7 +189,7 @@ class File
 			return 'Cannot find source file.';
 		}
 
-        self::invalidateFileCache($src);
+		self::invalidateFileCache($src);
 
 		if ($useStreams)
 		{
@@ -292,7 +292,7 @@ class File
 			Folder::create($baseDir);
 		}
 
-        self::invalidateFileCache($src);
+		self::invalidateFileCache($src);
 
 		if ($useStreams)
 		{

--- a/src/File.php
+++ b/src/File.php
@@ -305,24 +305,39 @@ class File
 		throw new FilesystemException(__METHOD__ . ': Failed to move file.');
 	}
 
-	/**
-	 * Invalidate any opcache for a newly written file immediately, if opcache* functions exist and if this was a PHP file.
-	 *
-	 * @param   string  $file  The path to the file just written to, to flush from opcache
-	 *
-	 * @return void
-	 */
-	public static function invalidateFileCache($file)
-	{
-		if (function_exists('opcache_invalidate'))
-		{
-			$info = pathinfo($file);
+    /**
+     * Invalidate opcache for a newly written/deleted file immediately, if opcache* functions exist and if this was a PHP file.
+     *
+     * First we check if opcache is enabled, and if the filepath given is a path to a PHP file.
+     * Then we check if the opcache_invalidate function is available, and if the host has restricted which scripts can use it.
+     * We do this to avoid a PHP warning.
+     *
+     * `opcache.restrict_api` can specify the path for files allowed to call `opcache_invalidate()`.
+     *
+     * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
+     * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
+     *
+     * If the host has this set, check whether the path in `opcache.restrict_api` matches
+     * the beginning of the path of the origin file.
+     *
+     * @param   string  $filepath   The path to the file just written to, to flush from opcache
+     * @param   boolean $force      If set to true, the script will be invalidated regardless of whether invalidation is necessary
+     *
+     * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate, or FALSE if the opcode cache is disabled.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public static function invalidateFileCache($filepath, $force = true)
+    {
+        if (ini_get('opcache.enable')
+            && '.php' === strtolower(substr($filepath, -4))
+            && function_exists('opcache_invalidate')
+            && (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0)
+        )
+        {
+            return opcache_invalidate($filepath, $force);
+        }
 
-			if (isset($info['extension']) && $info['extension'] === 'php')
-			{
-				// Force invalidation to be absolutely sure the opcache is cleared for this file.
-				opcache_invalidate($file, true);
-			}
-		}
-	}
+        return false;
+    }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -17,11 +17,11 @@ use Joomla\Filesystem\Exception\FilesystemException;
  */
 class File
 {
-    /**
-     * @var    boolean  true if OPCache enabled, and we have permission to invalidate files
-     * @since  __DEPLOY_VERSION__
-     */
-    protected static $canFlushFileCache;
+	/**
+	 * @var    boolean  true if OPCache enabled, and we have permission to invalidate files
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $canFlushFileCache;
 
 	/**
 	 * Strips the last extension off of a file name
@@ -320,61 +320,61 @@ class File
 		throw new FilesystemException(__METHOD__ . ': Failed to move file.');
 	}
 
-    /**
-     * Invalidate opcache for a newly written/deleted file immediately, if opcache* functions exist and if this was a PHP file.
-     *
-     * @param   string  $filepath   The path to the file just written to, to flush from opcache
-     * @param   boolean $force      If set to true, the script will be invalidated regardless of whether invalidation is necessary
-     *
-     * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate,
-     *                 or FALSE if the opcode cache is disabled or other conditions returning
-     *                 FALSE from opcache_invalidate (like file not found).
-     *
-     * @since __DEPLOY_VERSION__
-     */
-    public static function invalidateFileCache($filepath, $force = true)
-    {
-        if (self::canFlushFileCache() && '.php' === strtolower(substr($filepath, -4)))
-        {
-            return opcache_invalidate($filepath, $force);
-        }
+	/**
+	 * Invalidate opcache for a newly written/deleted file immediately, if opcache* functions exist and if this was a PHP file.
+	 *
+	 * @param   string  $filepath   The path to the file just written to, to flush from opcache
+	 * @param   boolean $force      If set to true, the script will be invalidated regardless of whether invalidation is necessary
+	 *
+	 * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate,
+	 *                 or FALSE if the opcode cache is disabled or other conditions returning
+	 *                 FALSE from opcache_invalidate (like file not found).
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public static function invalidateFileCache($filepath, $force = true)
+	{
+		if (self::canFlushFileCache() && '.php' === strtolower(substr($filepath, -4)))
+		{
+			return opcache_invalidate($filepath, $force);
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * First we check if opcache is enabled
-     * Then we check if the opcache_invalidate function is available
-     * Lastly we check if the host has restricted which scripts can use opcache_invalidate using opcache.restrict_api.
-     *
-     * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
-     * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
-     * If the host has this set, check whether the path in `opcache.restrict_api` matches
-     * the beginning of the path of the origin file.
-     *
-     * @return boolean TRUE if we can proceed to use opcache_invalidate to flush a file from the OPCache
-     *
-     * @since __DEPLOY_VERSION__
-     */
-    public static function canFlushFileCache()
-    {
-        if (isset(static::$canFlushFileCache))
-        {
-            return static::$canFlushFileCache;
-        }
+	/**
+	 * First we check if opcache is enabled
+	 * Then we check if the opcache_invalidate function is available
+	 * Lastly we check if the host has restricted which scripts can use opcache_invalidate using opcache.restrict_api.
+	 *
+	 * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
+	 * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
+	 * If the host has this set, check whether the path in `opcache.restrict_api` matches
+	 * the beginning of the path of the origin file.
+	 *
+	 * @return boolean TRUE if we can proceed to use opcache_invalidate to flush a file from the OPCache
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public static function canFlushFileCache()
+	{
+		if (isset(static::$canFlushFileCache))
+		{
+			return static::$canFlushFileCache;
+		}
 
-        if (ini_get('opcache.enable')
-            && function_exists('opcache_invalidate')
-            && (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0)
-        )
-        {
-            static::$canFlushFileCache = true;
-        }
-        else
-        {
-            static::$canFlushFileCache = false;
-        }
+		if (ini_get('opcache.enable')
+			&& function_exists('opcache_invalidate')
+			&& (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0)
+		)
+		{
+			static::$canFlushFileCache = true;
+		}
+		else
+		{
+			static::$canFlushFileCache = false;
+		}
 
-        return static::$canFlushFileCache;
-    }
+		return static::$canFlushFileCache;
+	}
 }

--- a/src/File.php
+++ b/src/File.php
@@ -189,6 +189,8 @@ class File
 			return 'Cannot find source file.';
 		}
 
+        self::invalidateFileCache($src);
+
 		if ($useStreams)
 		{
 			$stream = Stream::getStream();

--- a/src/File.php
+++ b/src/File.php
@@ -292,6 +292,8 @@ class File
 			Folder::create($baseDir);
 		}
 
+        self::invalidateFileCache($src);
+
 		if ($useStreams)
 		{
 			$stream = Stream::getStream();

--- a/src/File.php
+++ b/src/File.php
@@ -305,39 +305,39 @@ class File
 		throw new FilesystemException(__METHOD__ . ': Failed to move file.');
 	}
 
-    /**
-     * Invalidate opcache for a newly written/deleted file immediately, if opcache* functions exist and if this was a PHP file.
-     *
-     * First we check if opcache is enabled, and if the filepath given is a path to a PHP file.
-     * Then we check if the opcache_invalidate function is available, and if the host has restricted which scripts can use it.
-     * We do this to avoid a PHP warning.
-     *
-     * `opcache.restrict_api` can specify the path for files allowed to call `opcache_invalidate()`.
-     *
-     * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
-     * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
-     *
-     * If the host has this set, check whether the path in `opcache.restrict_api` matches
-     * the beginning of the path of the origin file.
-     *
-     * @param   string  $filepath   The path to the file just written to, to flush from opcache
-     * @param   boolean $force      If set to true, the script will be invalidated regardless of whether invalidation is necessary
-     *
-     * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate, or FALSE if the opcode cache is disabled.
-     *
-     * @since __DEPLOY_VERSION__
-     */
-    public static function invalidateFileCache($filepath, $force = true)
-    {
-        if (ini_get('opcache.enable')
-            && '.php' === strtolower(substr($filepath, -4))
-            && function_exists('opcache_invalidate')
-            && (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0)
-        )
-        {
-            return opcache_invalidate($filepath, $force);
-        }
+	/**
+	 * Invalidate opcache for a newly written/deleted file immediately, if opcache* functions exist and if this was a PHP file.
+	 *
+	 * First we check if opcache is enabled, and if the filepath given is a path to a PHP file.
+	 * Then we check if the opcache_invalidate function is available, and if the host has restricted which scripts can use it.
+	 * We do this to avoid a PHP warning.
+	 *
+	 * `opcache.restrict_api` can specify the path for files allowed to call `opcache_invalidate()`.
+	 *
+	 * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
+	 * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
+	 *
+	 * If the host has this set, check whether the path in `opcache.restrict_api` matches
+	 * the beginning of the path of the origin file.
+	 *
+	 * @param   string  $filepath   The path to the file just written to, to flush from opcache
+	 * @param   boolean $force      If set to true, the script will be invalidated regardless of whether invalidation is necessary
+	 *
+	 * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate, or FALSE if the opcode cache is disabled.
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public static function invalidateFileCache($filepath, $force = true)
+	{
+		if (ini_get('opcache.enable')
+			&& '.php' === strtolower(substr($filepath, -4))
+			&& function_exists('opcache_invalidate')
+			&& (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0)
+		)
+		{
+			return opcache_invalidate($filepath, $force);
+		}
 
-        return false;
-    }
+		return false;
+	}
 }


### PR DESCRIPTION
Based on feedback in the CMS repo, and consultation with the WordPress project, here is a new and improved method that will handle PHP warnings better as well as making more checks before running