### PR TITLE
Don't fail, if filenames are too long, shorten them instead

### DIFF
--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -44,7 +44,7 @@ class FileTest extends FilesystemTestCase
 	 *
 	 * @dataProvider  dataTestStripExt
 	 */
-	public function testStripExt($fileName, $nameWithoutExt)
+	public function testStripExt(string $fileName, string $nameWithoutExt): void
 	{
 		$this->assertEquals(
 			File::stripExt($fileName),
@@ -111,10 +111,10 @@ class FileTest extends FilesystemTestCase
 	 * @param   string  $expected    The expected safe file name
 	 * @param   string  $message     The message to show on failure of test
 	 *
-	 * @covers        Joomla\Filesystem\File::makeSafe
+	 * @covers        \Joomla\Filesystem\File::makeSafe
 	 * @dataProvider  dataTestMakeSafe
 	 */
-	public function testMakeSafe($name, $stripChars, $expected, $message)
+	public function testMakeSafe(string $name, array $stripChars, string $expected, string $message): void
 	{
 		$this->assertEquals(File::makeSafe($name, $stripChars), $expected, $message);
 	}
@@ -122,7 +122,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test copy method.
 	 */
-	public function testCopyWithPathArgPassed()
+	public function testCopyWithPathArgPassed(): void
 	{
 		$name       = 'tempFile';
 		$copiedName = 'tempCopiedFileName';
@@ -148,7 +148,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test copy method.
 	 */
-	public function testCopyWithoutPathArgPassed()
+	public function testCopyWithoutPathArgPassed(): void
 	{
 		$name       = 'tempFile';
 		$copiedName = 'tempCopiedFileName';
@@ -174,7 +174,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test copy method using streams.
 	 */
-	public function testCopyWithStreams()
+	public function testCopyWithStreams(): void
 	{
 		$name       = 'tempFile';
 		$copiedName = 'tempCopiedFileName';
@@ -200,7 +200,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test makeCopy method for an exception
 	 */
-	public function testCopySrcDontExist()
+	public function testCopySrcDontExist(): void
 	{
 		$this->expectException(\UnexpectedValueException::class);
 
@@ -213,7 +213,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test delete method.
 	 */
-	public function testDeleteForSingleFile()
+	public function testDeleteForSingleFile(): void
 	{
 		$name = 'tempFile';
 		$data = 'Lorem ipsum dolor sit amet';
@@ -232,7 +232,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test delete method.
 	 */
-	public function testDeleteForArrayOfFiles()
+	public function testDeleteForArrayOfFiles(): void
 	{
 		$name1 = 'tempFile1';
 		$name2 = 'tempFile2';
@@ -257,7 +257,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Tests the File::move method.
 	 */
-	public function testMoveWithPathArgPassed()
+	public function testMoveWithPathArgPassed(): void
 	{
 		$name      = 'tempFile';
 		$movedName = 'tempCopiedFileName';
@@ -277,7 +277,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Tests the File::move method.
 	 */
-	public function testMoveWithoutPathArgPassed()
+	public function testMoveWithoutPathArgPassed(): void
 	{
 		$name      = 'tempFile';
 		$movedName = 'tempCopiedFileName';
@@ -297,7 +297,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Tests the File::move method.
 	 */
-	public function testMoveWithStreams()
+	public function testMoveWithStreams(): void
 	{
 		$name      = 'tempFile';
 		$movedName = 'tempCopiedFileName';
@@ -314,11 +314,10 @@ class FileTest extends FilesystemTestCase
 		);
 	}
 
-
 	/**
 	 * Test the File::move method where source file doesn't exist.
 	 */
-	public function testMoveSrcDontExist()
+	public function testMoveSrcDontExist(): void
 	{
 		$name      = 'tempFile';
 		$movedName = 'tempCopiedFileName';
@@ -332,7 +331,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test write method.
 	 */
-	public function testWrite()
+	public function testWrite(): void
 	{
 		$name = 'tempFile';
 		$data = 'Lorem ipsum dolor sit amet';
@@ -352,10 +351,10 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test write method when appending to a file.
 	 */
-	public function testWriteWithAppend()
+	public function testWriteWithAppend(): void
 	{
-		$name = 'tempFile.txt';
-		$data = 'Lorem ipsum dolor sit amet';
+		$name       = 'tempFile.txt';
+		$data       = 'Lorem ipsum dolor sit amet';
 		$appendData = PHP_EOL . $data;
 
 		$this->assertTrue(
@@ -378,7 +377,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test write method.
 	 */
-	public function testWriteCreatesMissingDirectory()
+	public function testWriteCreatesMissingDirectory(): void
 	{
 		$name = 'tempFile';
 		$data = 'Lorem ipsum dolor sit amet';
@@ -398,7 +397,7 @@ class FileTest extends FilesystemTestCase
 	/**
 	 * Test write method.
 	 */
-	public function testWriteWithStreams()
+	public function testWriteWithStreams(): void
 	{
 		$name = 'tempFile';
 		$data = 'Lorem ipsum dolor sit amet';
@@ -416,32 +415,49 @@ class FileTest extends FilesystemTestCase
 	}
 
 	/**
+	 * Provides the data to test the upload method.
+	 *
+	 * @return  \Generator
+	 */
+	public function dataTestUpload(): \Generator
+	{
+		/*
+		 *  This case describes the happy path
+		 */
+		yield 'valid filename' => [
+			'uploadedFileName' => 'uploadedFileName',
+		];
+
+		/*
+		 *  This case provides a filename longer than the allowed 250 bytes.
+		 *  @see [Comment in the PHP manual](https://www.php.net/manual/en/function.move-uploaded-file.php#103190)
+		 */
+		yield 'too long filename' => [
+			'uploadedFileName' => str_repeat('a', 260),
+		];
+	}
+
+	/**
 	 * Test upload method.
 	 *
 	 * @backupGlobals enabled
+	 * @dataProvider  dataTestUpload
 	 */
-	public function testUpload()
+	public function testUpload(string $uploadedFileName): void
 	{
 		include_once __DIR__ . '/Stubs/PHPUploadStub.php';
 
-		$name = 'tempFile';
-		$data = 'Lorem ipsum dolor sit amet';
-		$uploadedFileName = 'uploadedFileName';
-
-		if (!File::write($this->testPath . '/' . $name, $data))
-		{
-			$this->markTestSkipped('The test file could not be created.');
-		}
+		$tempFile = __DIR__ . '/fixtures/tempFile.txt';
 
 		$_FILES = [
 			'test' => [
 				'name'     => 'test.jpg',
-				'tmp_name' => $this->testPath . '/' . $name,
+				'tmp_name' => $tempFile,
 			],
 		];
 
 		$this->assertTrue(
-			File::upload($this->testPath . '/' . $name, $this->testPath . '/' . $uploadedFileName)
+			File::upload($tempFile, $this->testPath . '/' . $uploadedFileName)
 		);
 	}
 
@@ -450,28 +466,22 @@ class FileTest extends FilesystemTestCase
 	 *
 	 * @backupGlobals enabled
 	 */
-	public function testUploadWithStreams()
+	public function testUploadWithStreams(): void
 	{
 		include_once __DIR__ . '/Stubs/PHPUploadStub.php';
 
-		$name = 'tempFile';
-		$data = 'Lorem ipsum dolor sit amet';
+		$tempFile         = __DIR__ . '/fixtures/tempFile.txt';
 		$uploadedFileName = 'uploadedFileName';
-
-		if (!File::write($this->testPath . '/' . $name, $data))
-		{
-			$this->markTestSkipped('The test file could not be created.');
-		}
 
 		$_FILES = [
 			'test' => [
 				'name'     => 'test.jpg',
-				'tmp_name' => $this->testPath . '/' . $name,
+				'tmp_name' => $tempFile,
 			],
 		];
 
 		$this->assertTrue(
-			File::upload($this->testPath . '/' . $name, $this->testPath . '/' . $uploadedFileName, true)
+			File::upload($tempFile, $this->testPath . '/' . $uploadedFileName, true)
 		);
 	}
 
@@ -480,12 +490,12 @@ class FileTest extends FilesystemTestCase
 	 *
 	 * @backupGlobals enabled
 	 */
-	public function testUploadToNestedDirectory()
+	public function testUploadToNestedDirectory(): void
 	{
 		include_once __DIR__ . '/Stubs/PHPUploadStub.php';
 
-		$name = 'tempFile';
-		$data = 'Lorem ipsum dolor sit amet';
+		$name             = 'tempFile';
+		$data             = 'Lorem ipsum dolor sit amet';
 		$uploadedFileName = 'uploadedFileName';
 
 		if (!File::write($this->testPath . '/' . $name . '.txt', $data))
@@ -501,7 +511,10 @@ class FileTest extends FilesystemTestCase
 		];
 
 		$this->assertTrue(
-			File::upload($this->testPath . '/' . $name . '.txt', $this->testPath . '/' . $name . '/' . $uploadedFileName)
+			File::upload(
+				$this->testPath . '/' . $name . '.txt',
+				$this->testPath . '/' . $name . '/' . $uploadedFileName
+			)
 		);
 	}
 }

--- a/Tests/HelperTest.php
+++ b/Tests/HelperTest.php
@@ -25,7 +25,7 @@ class HelperTest extends TestCase
 		);
 
 		$this->assertTrue(
-			is_numeric(Helper::remotefsize('https://www.joomla.org')),
+			is_numeric(Helper::remotefsize('https://www.example.org')),
 			'Line:' . __LINE__ . ' for a valid remote file, returned size should be numeric.'
 		);
 

--- a/Tests/fixtures/tempFile.txt
+++ b/Tests/fixtures/tempFile.txt
@@ -1,0 +1,1 @@
+Lorem ipsum dolor sit amet

--- a/src/File.php
+++ b/src/File.php
@@ -50,6 +50,9 @@ class File
 		// Remove any trailing dots, as those aren't ever valid file names.
 		$file = rtrim($file, '.');
 
+		// Shorten to maximum length, if necessary
+		$file = self::shortenIfTooLong($file);
+
 		return $file;
 	}
 
@@ -120,7 +123,7 @@ class File
 	 */
 	public static function delete($file)
 	{
-		$files = (array)$file;
+		$files = (array) $file;
 
 		foreach ($files as $file)
 		{
@@ -267,7 +270,7 @@ class File
 	public static function upload($src, $dest, $useStreams = false)
 	{
 		// Ensure that the path is valid and clean
-		$dest = Path::clean(self::shortenIfTooLong($dest));
+		$dest = Path::clean($dest);
 
 		// Create the destination directory if it does not exist
 		$baseDir = \dirname($dest);
@@ -347,12 +350,14 @@ class File
 		if (strlen($info['filename']) > $maxLen)
 		{
 			$path = $info['dirname'] ?? '';
+
 			if ($path > '')
 			{
 				$path .= '/';
 			}
 
 			$ext = $info['extension'] ?? '';
+
 			if ($ext > '')
 			{
 				$ext = '.' . $ext;

--- a/src/File.php
+++ b/src/File.php
@@ -349,7 +349,7 @@ class File
 
 		if (strlen($info['filename']) > $maxLen)
 		{
-			$path = $info['dirname'] ?? '';
+			$path = $info['dirname'] === '.' ? '' : $info['dirname'];
 
 			if ($path > '')
 			{


### PR DESCRIPTION
### Summary of Changes

The length of filenames is restricted to 250 characters, `move_uploaded_files()` already fails with length above 247 characters.(as stated in a [comment in the PHP manual](https://www.php.net/manual/en/function.move-uploaded-file.php#103190)).

With this PR, filenames (i.e., the basename plus the extension) are shortend to 240 characters, if their length exceed that length with the `File::makeSafe()` method. The directory and the extension are preserved.

Changes affecting tests only:
* The HelperTest addresses example.org instead of joomla.org, which seems to be more reliable.

### Testing Instructions

The change is covered by unit tests.
Call `File::makeSafe()` with a filename with more than 240 characters. The result should be a sanitised version of the filename with a maximum length of 240 characters.

### Documentation Changes Required

Probably.