### PR TITLE
Add File::getExt()

### DIFF
--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -40,6 +40,7 @@ class FileTest extends FilesystemTestCase
             'foobar.zip',
             'zip',
         ];
+
         yield [
             '.htaccess',
             'htaccess',

--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -15,6 +15,62 @@ use Joomla\Filesystem\File;
 class FileTest extends FilesystemTestCase
 {
     /**
+     * Provides the data to test the getExt method.
+     *
+     * @return  \Generator
+     */
+    public function dataTestGetExt(): \Generator
+    {
+        yield [
+            'foobar.php',
+            'php',
+        ];
+
+        yield [
+            'foobar..php',
+            'php',
+        ];
+
+        yield [
+            'foobar.php.',
+            '',
+        ];
+
+        yield [
+            'foobar.zip',
+            'zip',
+        ];
+
+
+        yield [
+            '.htaccess',
+            'htaccess',
+        ];
+
+        yield [
+            'readme',
+            '',
+        ];
+    }
+
+    /**
+     * Test getExt method
+     *
+     * @param   string  $fileName   The name of the file with extension
+     * @param   string  $extension  File extension
+     *
+     * @dataProvider  dataTestGetExt
+     */
+    public function testGetExt($fileName, $extension)
+    {
+        $this->assertEquals(
+            File::getExt($fileName),
+            $extension,
+            'File extension should be returned'
+        );
+    }
+
+    /**
      * Provides the data to test the stripExt method.
      *
      * @return  \Generator

--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -40,8 +40,6 @@ class FileTest extends FilesystemTestCase
             'foobar.zip',
             'zip',
         ];
-
-
         yield [
             '.htaccess',
             'htaccess',

--- a/src/File.php
+++ b/src/File.php
@@ -19,6 +19,34 @@ use Joomla\Filesystem\Exception\FilesystemException;
 class File
 {
     /**
+     * Gets the extension of a file name
+     *
+     * @param   string  $file  The file name
+     *
+     * @return  string  The file extension
+     *
+     * @since   3.0.0
+     */
+    public static function getExt($file)
+    {
+        // String manipulation should be faster than pathinfo() on newer PHP versions.
+        $dot = strrpos($file, '.');
+
+        if ($dot === false) {
+            return '';
+        }
+
+        $ext = substr($file, $dot + 1);
+
+        // Extension cannot contain slashes.
+        if (strpos($ext, '/') !== false || (DIRECTORY_SEPARATOR === '\\' && strpos($ext, '\\') !== false)) {
+            return '';
+        }
+
+        return $ext;
+    }
+
+    /**
      * Strips the last extension off of a file name
      *
      * @param   string  $file  The file name


### PR DESCRIPTION
### Summary of Changes
This PR adds the method `getExt()` to the `File` class, as it exists in the CMS Filesystem package.

 
### Testing Instructions
There are unittests for this...