### PR TITLE
Transliteration for filenames in File::makeSafe()

### DIFF
--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -103,12 +103,21 @@ class FileTest extends FilesystemTestCase
             'Files starting with a fullstop should be allowed when strip chars parameter is empty',
         ];
 
-        yield [
-            'Änderüng_âsceñt.txt',
-            [],
-            'Anderung_ascent.txt',
-            'Files with non-ascii characters should be transliterated',
-        ];
+        if (function_exists('transliterator_transliterate') && function_exists('iconv')) {
+            yield [
+                'Änderüng_âsceñt.txt',
+                [],
+                'Anderung_ascent.txt',
+                'Files with non-ascii characters should be transliterated',
+            ];
+        } else {
+            yield [
+                'Änderüng_âsceñt.txt',
+                [],
+                'nderng_scet.txt',
+                'Files with non-ascii characters should be removed when transliteration is not possible',
+            ];
+        }
     }
 
     /**

--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -102,6 +102,13 @@ class FileTest extends FilesystemTestCase
             '.gitignore',
             'Files starting with a fullstop should be allowed when strip chars parameter is empty',
         ];
+
+        yield [
+            'Änderüng_âsceñt.txt',
+            [],
+            'Anderung_ascent.txt',
+            'Files with non-ascii characters should be transliterated',
+        ];
     }
 
     /**
@@ -117,7 +124,7 @@ class FileTest extends FilesystemTestCase
      */
     public function testMakeSafe($name, $stripChars, $expected, $message)
     {
-        $this->assertEquals(File::makeSafe($name, $stripChars), $expected, $message);
+        $this->assertEquals($expected, File::makeSafe($name, $stripChars), $message);
     }
 
     /**

--- a/src/File.php
+++ b/src/File.php
@@ -44,14 +44,19 @@ class File
      */
     public static function makeSafe($file, array $stripChars = ['#^\.#'])
     {
-        $regex = array_merge(['#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#'], $stripChars);
+        // Try transliterating the file name using the native php function
+        if (function_exists('transliterator_transliterate') && function_exists('iconv')) {
+            // Using iconv to ignore characters that can't be transliterated
+            $file = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII', $file));
+        }
 
-        $file = preg_replace($regex, '', $file);
+        $regex = array_merge(['#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#'], $stripChars);
+        $file  = preg_replace($regex, '', $file);
 
         // Remove any trailing dots, as those aren't ever valid file names.
         $file = rtrim($file, '.');
 
-        return $file;
+        return trim($file);
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes
This adds the transliteration feature for `File::makeSafe()´ from the CMS Filesystem package to this File class.

### Testing Instructions
There are unittests...