### PR TITLE
[2.x] Add File::getExt()

### DIFF
--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -14,6 +14,61 @@ use Joomla\Filesystem\File;
 class FileTest extends FilesystemTestCase
 {
 	/**
+	 * Provides the data to test the getExt method.
+	 *
+	 * @return  \Generator
+	 */
+	public function dataTestGetExt(): \Generator
+	{
+		yield [
+			'foobar.php',
+			'php',
+		];
+
+		yield [
+			'foobar..php',
+			'php',
+		];
+
+		yield [
+			'foobar.php.',
+			'',
+		];
+
+		yield [
+			'foobar.zip',
+			'zip',
+		];
+
+		yield [
+			'.htaccess',
+			'htaccess',
+		];
+
+		yield [
+			'readme',
+			'',
+		];
+	}
+
+	/**
+	 * Test getExt method
+	 *
+	 * @param   string  $fileName   The name of the file with extension
+	 * @param   string  $extension  File extension
+	 *
+	 * @dataProvider  dataTestGetExt
+	 */
+	public function testGetExt($fileName, $extension)
+	{
+		$this->assertEquals(
+			File::getExt($fileName),
+			$extension,
+			'File extension should be returned'
+		);
+	}
+
+	/**
 	 * Provides the data to test the stripExt method.
 	 *
 	 * @return  \Generator

--- a/src/File.php
+++ b/src/File.php
@@ -18,6 +18,34 @@ use Joomla\Filesystem\Exception\FilesystemException;
 class File
 {
 	/**
+	 * Gets the extension of a file name
+	 *
+	 * @param   string  $file  The file name
+	 *
+	 * @return  string  The file extension
+	 *
+	 * @since   2.1.0
+	 */
+	public static function getExt($file)
+	{
+		// String manipulation should be faster than pathinfo() on newer PHP versions.
+		$dot = strrpos($file, '.');
+
+		if ($dot === false) {
+			return '';
+		}
+
+		$ext = substr($file, $dot + 1);
+
+		// Extension cannot contain slashes.
+		if (strpos($ext, '/') !== false || (DIRECTORY_SEPARATOR === '\\' && strpos($ext, '\\') !== false)) {
+			return '';
+		}
+
+		return $ext;
+	}
+
+	/**
 	 * Strips the last extension off of a file name
 	 *
 	 * @param   string  $file  The file name

--- a/src/File.php
+++ b/src/File.php
@@ -31,14 +31,16 @@ class File
 		// String manipulation should be faster than pathinfo() on newer PHP versions.
 		$dot = strrpos($file, '.');
 
-		if ($dot === false) {
+		if ($dot === false)
+		{
 			return '';
 		}
 
 		$ext = substr($file, $dot + 1);
 
 		// Extension cannot contain slashes.
-		if (strpos($ext, '/') !== false || (DIRECTORY_SEPARATOR === '\\' && strpos($ext, '\\') !== false)) {
+		if (strpos($ext, '/') !== false || (DIRECTORY_SEPARATOR === '\\' && strpos($ext, '\\') !== false))
+		{
 			return '';
 		}
 


### PR DESCRIPTION
### Summary of Changes
This PR adds the method getExt() to the File class, as it exists in the CMS Filesystem package.

### Testing Instructions
There are unittests for this...