### PR TITLE
set_time_limit php 8

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -218,7 +218,8 @@ class File
 	 */
 	public static function write($file, &$buffer, $useStreams = false, $appendToFile = false)
 		{
-		if (\function_exists('set_time_limit')) {
+		if (\function_exists('set_time_limit')) 
+		{
 			@set_time_limit(ini_get('max_execution_time'));
 		}
 

--- a/src/File.php
+++ b/src/File.php
@@ -217,8 +217,8 @@ class File
 	 * @since   1.0
 	 */
 	public static function write($file, &$buffer, $useStreams = false, $appendToFile = false)
-		{
-		if (\function_exists('set_time_limit')) 
+	{
+		if (\function_exists('set_time_limit'))
 		{
 			@set_time_limit(ini_get('max_execution_time'));
 		}

--- a/src/File.php
+++ b/src/File.php
@@ -217,8 +217,10 @@ class File
 	 * @since   1.0
 	 */
 	public static function write($file, &$buffer, $useStreams = false, $appendToFile = false)
-	{
-		@set_time_limit(ini_get('max_execution_time'));
+		{
+		if (\function_exists('set_time_limit')) {
+			@set_time_limit(ini_get('max_execution_time'));
+		}
 
 		// If the destination directory doesn't exist we need to create it
 		if (!file_exists(\dirname($file)))

--- a/src/File.php
+++ b/src/File.php
@@ -220,7 +220,7 @@ class File
 	{
 		if (\function_exists('set_time_limit'))
 		{
-			@set_time_limit(ini_get('max_execution_time'));
+			set_time_limit(ini_get('max_execution_time'));
 		}
 
 		// If the destination directory doesn't exist we need to create it

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -33,7 +33,8 @@ abstract class Folder
 	 */
 	public static function copy($src, $dest, $path = '', $force = false, $useStreams = false)
 	{
-  		if (\function_exists('set_time_limit')) {
+		if (\function_exists('set_time_limit')) 
+		{
 			@set_time_limit(ini_get('max_execution_time'));
 		}
 

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -33,7 +33,9 @@ abstract class Folder
 	 */
 	public static function copy($src, $dest, $path = '', $force = false, $useStreams = false)
 	{
-		@set_time_limit(ini_get('max_execution_time'));
+  		if (\function_exists('set_time_limit')) {
+			@set_time_limit(ini_get('max_execution_time'));
+		}
 
 		if ($path)
 		{

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -33,7 +33,7 @@ abstract class Folder
 	 */
 	public static function copy($src, $dest, $path = '', $force = false, $useStreams = false)
 	{
-		if (\function_exists('set_time_limit')) 
+		if (\function_exists('set_time_limit'))
 		{
 			@set_time_limit(ini_get('max_execution_time'));
 		}


### PR DESCRIPTION
Also see https://github.com/joomla/joomla-cms/pull/41523

### Summary of Changes
some hosts disable set_time_limit in php

> Prior to PHP 8.0.0, it was possible for the @ operator to disable critical errors that will terminate script execution. For example, prepending @ to a call of a function which did not exist, by being unavailable or mistyped, would cause the script to terminate with no indication as to why.

This PR replaces the @ with a function_exists check

### Testing Instructions
code review or in php.ini
disable_functions = set_time_limit



### Actual result BEFORE applying this Pull Request
Admin dashboard loads with an error
finder index ends with an error


### Expected result AFTER applying this Pull Request
everything works
