### PR TITLE
Fix incorrect non-empty path check

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -190,7 +190,11 @@ class Path
      */
     public static function clean($path, $ds = \DIRECTORY_SEPARATOR)
     {
-        if (!\is_string($path) && !empty($path)) {
+        if ($path === '') {
+            return '';
+        }
+
+        if (!\is_string($path)) {
             throw new \InvalidArgumentException('You must specify a non-empty path to clean');
         }
 

--- a/src/Path.php
+++ b/src/Path.php
@@ -190,7 +190,7 @@ class Path
      */
     public static function clean($path, $ds = \DIRECTORY_SEPARATOR)
     {
-        if (!\is_string($path)) {
+        if (!\is_string($path) && !empty($path)) {
             throw new \InvalidArgumentException('You must specify a non-empty path to clean');
         }
 


### PR DESCRIPTION
Using is_string() alone is insufficient as it returns true for empty path which is not expected

Pull Request for Issue #62 

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
