### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/Tests/FolderTest.php
+++ b/Tests/FolderTest.php
@@ -8,8 +8,8 @@
 namespace Joomla\Filesystem\Tests;
 
 use Joomla\Filesystem\Exception\FilesystemException;
-use Joomla\Filesystem\Folder;
 use Joomla\Filesystem\File;
+use Joomla\Filesystem\Folder;
 use Joomla\Filesystem\Path;
 
 /**

--- a/src/Exception/FilesystemException.php
+++ b/src/Exception/FilesystemException.php
@@ -27,7 +27,7 @@ class FilesystemException extends \RuntimeException
      * @param   integer          $code      The code
      * @param   \Throwable|null  $previous  A previous exception
      */
-    public function __construct($message = "", $code = 0, \Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct(
             Path::removeRoot($message),


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no