### PR TITLE
Remove check for chmod in File::delete()

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -159,10 +159,6 @@ class File
             $file     = Path::clean($file);
             $filename = basename($file);
 
-            if (!Path::canChmod($file)) {
-                throw new FilesystemException(__METHOD__ . ': Failed deleting inaccessible file ' . $filename);
-            }
-
             // Try making the file writable first. If it's read-only, it can't be deleted
             // on Windows, even if the parent folder is writable
             @chmod($file, 0777);


### PR DESCRIPTION
### Summary of Changes
When refactoring the CMS to use the framework filesystem package instead of the CMS filesystem package (https://github.com/joomla/joomla-cms/pull/43359) it turns out that the check for chmod makes the system tests fail. This PR removes that check, since it seems unreliable.

### Testing Instructions
Codereview?