### PR TITLE
Meaningfull error for copy method

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -133,7 +133,7 @@ class File
         }
 
         if (!@ copy($src, $dest)) {
-            throw new FilesystemException(__METHOD__ . ': Copy failed.');
+            throw new FilesystemException(sprintf('%1$s(%2$s, %3$s): %4$s', __METHOD__, $src, $dest, 'Copy failed'));
         }
 
         self::invalidateFileCache($dest);


### PR DESCRIPTION
Currently if the the copy method fails, it gives no details about what paths where provided as the parameters. It makes it had to debug (especially installer errors). This adds a proper source/destination details like in the stream copy above.

### Summary of Changes
Expands the error message.

### Testing Instructions
Try to install an extension with files added in the extension manifest but not in the zip file.

### Documentation Changes Required
No