### PR TITLE
[3.x] Port improvements for opcache invalidation from CMS - redo PR #38

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -206,6 +206,8 @@ class File
             return 'Cannot find source file.';
         }
 
+        self::invalidateFileCache($src);
+
         if ($useStreams) {
             $stream = Stream::getStream();
 

--- a/src/File.php
+++ b/src/File.php
@@ -163,13 +163,19 @@ class File
             // on Windows, even if the parent folder is writable
             @chmod($file, 0777);
 
-            // In case of restricted permissions we zap it one way or the other
-            // as long as the owner is either the webserver or the ftp
+            /**
+             * Invalidate the OPCache for the file before actually deleting it
+             * @link https://www.php.net/manual/en/function.opcache-invalidate.php#116372
+             */
+            self::invalidateFileCache($file);
+
+            /**
+             * In case of restricted permissions we zap it one way or the other
+             * as long as the owner is either the webserver or the ftp
+             */
             if (!@ unlink($file)) {
                 throw new FilesystemException(__METHOD__ . ': Failed deleting ' . $filename);
             }
-
-            self::invalidateFileCache($file);
         }
 
         return true;

--- a/src/File.php
+++ b/src/File.php
@@ -19,6 +19,12 @@ use Joomla\Filesystem\Exception\FilesystemException;
 class File
 {
     /**
+     * @var    boolean  true if OPCache enabled, and we have permission to invalidate files
+     * @since  3.2.0
+     */
+    protected static $canFlushFileCache;
+
+    /**
      * Gets the extension of a file name
      *
      * @param   string  $file  The file name
@@ -331,7 +337,7 @@ class File
     }
 
     /**
-     * Invalidate any opcache for a newly written file immediately, if opcache* functions exist and if this was a PHP file.
+     * Invalidate any opcache immediately for a file if opcache* functions are enabled and the file is a PHP file.
      *
      * @param   string  $file  The path to the file just written to, to flush from opcache
      *
@@ -339,13 +345,29 @@ class File
      */
     public static function invalidateFileCache($file)
     {
-        if (function_exists('opcache_invalidate')) {
-            $info = pathinfo($file);
+        /**
+         * Check if we can invalidate the opcache. This is the case if
+         * - opcache is enabled, and
+         * - the opcache_invalidate function is available, and
+         * - calling opcache_invalidate is not restricted by opcache.restrict_api
+         *   or it is restricted to allow the currently executing script
+         */
+        if (!isset(static::$canFlushFileCache)) {
+            static::$canFlushFileCache
+                = ini_get('opcache.enable')
+                && \function_exists('opcache_invalidate')
+                && (!ini_get('opcache.restrict_api') || str_starts_with(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')));
+        }
 
-            if (isset($info['extension']) && $info['extension'] === 'php') {
-                // Force invalidation to be absolutely sure the opcache is cleared for this file.
-                opcache_invalidate($file, true);
-            }
+        if (!static::$canFlushFileCache) {
+            return;
+        }
+
+        $info = pathinfo($file);
+
+        if (isset($info['extension']) && $info['extension'] === 'php') {
+            // Force invalidation to be absolutely sure the opcache is cleared for this file.
+            opcache_invalidate($file, true);
         }
     }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -165,8 +165,10 @@ class File
             $file     = Path::clean($file);
             $filename = basename($file);
 
-            // Try making the file writable first. If it's read-only, it can't be deleted
-            // on Windows, even if the parent folder is writable
+            /**
+             * Try making the file writable first. If it's read-only, it can't be deleted
+             * on Windows, even if the parent folder is writable
+             */
             @chmod($file, 0777);
 
             /**

--- a/src/File.php
+++ b/src/File.php
@@ -302,6 +302,8 @@ class File
             Folder::create($baseDir);
         }
 
+        self::invalidateFileCache($src);
+
         if ($useStreams) {
             $stream = Stream::getStream();
 


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

This pull request is a redo of PR #38 , which was closed by its author for unrelated reasons.

In opposite to that PR, it does not introduce a new method to check if opcache can be invalidated but checks that locally in the `invalidateFileCache` method, and it does not extend the `invalidateFileCache` method by a new parameter if the invalidation shall be forced.

Besides these differences in implementation, the changes here are functionally the same as in the closed PR.

The changes were once implemented in the file system classes of the CMS with PR https://github.com/joomla/joomla-cms/pull/32915 , which was intensively tested by me at that time.

In detail the changes are following, done with separate commits in this PR so they can be easily verified:
- When deleting a file, invalidate the OPCache for the file before actually deleting it.
See  https://www.php.net/manual/en/function.opcache-invalidate.php#116372 .
- When moving a file, invalidate the OPCache for the file before actually moving it.
This is done in the `move` method and for the temporary upload file also in the `upload` method.
- Better check if opcache_invalidate is possible (check also if opcache is enabled at all and if there is a restriction by opcache.restrict_api) and save the result in a static variable.
- Code style fix for multi-line comment not related to the other changes from this PR.

### Testing Instructions

_Will be added soon._

### Documentation Changes Required

None.