### PR TITLE
 [3.x] Cast ini values to integer in getFileUploadMaxSize

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -286,8 +286,8 @@ class Helper
      */
     public static function getFileUploadMaxSize()
     {
-        $maxSize   = self::parseSize(\ini_get('post_max_size'));
-        $uploadMax = self::parseSize(\ini_get('upload_max_filesize'));
+        $maxSize   = (int) self::parseSize(\ini_get('post_max_size'));
+        $uploadMax = (int) self::parseSize(\ini_get('upload_max_filesize'));
 
         if ($uploadMax > 0 && ($uploadMax < $maxSize || $maxSize === 0)) {
             $maxSize = $uploadMax;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/45905

### Summary of Changes

This pull request (PR) changes the internal variables which are used in the `Helper::getFileUploadMaxSize()` method to calculate the result to be integer by casting the result of the `self::parseSize` calls (which always return floats as being the result of `round` but only can have integer values) to integer before using integer comparisons on these variables.

Currently the `$maxSize === 0` check is always false as `$maxSize` is always a float.

### Testing Instructions
1. Update php.ini file to set post_max_size to 0 (and restart PHP/Apache)
2. Attempt to upload any extension from the Upload Package File tab on the Manage Extensions page

### Expected result
Extension should be uploaded and deployed successfully.

### Actual result
Upload fails instant with the following message:
"The selected file cannot be uploaded as it is bigger than the maximum upload size."

### Documentation Changes Required

None.