### PR TITLE
Backport File:exists and Folder:exists from CMS

### DIFF
--- a/Tests/FileTest.php
+++ b/Tests/FileTest.php
@@ -564,4 +564,35 @@ class FileTest extends FilesystemTestCase
             File::upload($this->testPath . '/' . $name . '.txt', $this->testPath . '/' . $name . '/' . $uploadedFileName)
         );
     }
+
+    /**
+     * Test exists method.
+     */
+    public function testExistsForExistingFile()
+    {
+        $name = 'tempFile';
+        $data = 'Lorem ipsum dolor sit amet';
+
+        if (!File::write($this->testPath . '/' . $name, $data)) {
+            $this->markTestSkipped('The test file could not be created.');
+        }
+
+        $this->assertTrue(
+            File::exists($this->testPath . '/' . $name),
+            'The file exists.'
+        );
+    }
+
+    /**
+     * Test exists method.
+     */
+    public function testExistsForNonexistingFile()
+    {
+        $name = 'nonExistingTempFile';
+
+        $this->assertFalse(
+            File::exists($this->testPath . '/' . $name),
+            'The file does not exists.'
+        );
+    }
 }

--- a/Tests/FolderTest.php
+++ b/Tests/FolderTest.php
@@ -921,4 +921,35 @@ class FolderTest extends FilesystemTestCase
             Folder::makeSafe('test1/testdirectory')
         );
     }
+
+
+    /**
+     * Test exists method.
+     */
+    public function testExistsForExistingFolder()
+    {
+        $name = 'tempFolder';
+
+        if (!Folder::create($this->testPath . '/' . $name)) {
+            $this->markTestSkipped('The test directory could not be created.');
+        }
+
+        $this->assertTrue(
+            Folder::exists($this->testPath . '/' . $name),
+            'The folder exists.'
+        );
+    }
+
+    /**
+     * Test exists method.
+     */
+    public function testExistsForNonexistingFolder()
+    {
+        $name = 'nonExistingTempFolder';
+
+        $this->assertFalse(
+            Folder::exists($this->testPath . '/' . $name),
+            'The folder does not exists.'
+        );
+    }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -372,4 +372,17 @@ class File
             opcache_invalidate($file, true);
         }
     }
+
+    /**
+     * Wrapper for the standard file_exists function
+     *
+     * @param   string  $file  File path
+     *
+     * @return  boolean  True if path is a file
+     *
+     */
+    public static function exists($file): bool
+    {
+        return is_file(Path::clean($file));
+    }
 }

--- a/src/File.php
+++ b/src/File.php
@@ -381,7 +381,7 @@ class File
      * @return  boolean  True if path is a file
      *
      */
-    public static function exists($file): bool
+    public static function exists(string $file): bool
     {
         return is_file(Path::clean($file));
     }

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -547,4 +547,16 @@ abstract class Folder
 
         return preg_replace($regex, '', $path);
     }
+
+    /**
+     * Wrapper for the standard is_dir function
+     *
+     * @param   string  $path  Folder path
+     *
+     * @return  boolean  True if path is a folder
+     */
+    public static function exists($path): bool
+    {
+        return is_dir(Path::clean($path));
+    }
 }

--- a/src/Folder.php
+++ b/src/Folder.php
@@ -555,7 +555,7 @@ abstract class Folder
      *
      * @return  boolean  True if path is a folder
      */
-    public static function exists($path): bool
+    public static function exists(string $path): bool
     {
         return is_dir(Path::clean($path));
     }


### PR DESCRIPTION
Pull Request for Issue "Missing exists method for smoother transition from CMS package"

### Summary of Changes

Add File::exists and Folder::exists method with tests.

### Testing Instructions
Test both methods

### Documentation Changes Required
Add new methods
