### PR TITLE
Harden upload method against executable file uploads

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -19,6 +19,17 @@ use Joomla\Filesystem\Exception\FilesystemException;
 class File
 {
     /**
+     * An array containing a list of extensions for files that are typically
+     * executable directly in the webserver context, potentially resulting in code executions
+     *
+     * @since 3.3.0
+     */
+    public const FORBIDDEN_FILE_EXTENSIONS = [
+        'php', 'phps', 'pht', 'phtml', 'php3', 'php4', 'php5', 'php6', 'php7', 'asp',
+        'php8', 'php9', 'phar', 'inc', 'pl', 'cgi', 'fcgi', 'java', 'jar', 'py', 'aspx',
+    ];
+
+    /**
      * @var    boolean  true if OPCache enabled, and we have permission to invalidate files
      * @since  3.2.0
      */
@@ -289,17 +300,35 @@ class File
     /**
      * Moves an uploaded file to a destination folder
      *
-     * @param   string   $src         The name of the php (temporary) uploaded file
-     * @param   string   $dest        The path (including filename) to move the uploaded file to
-     * @param   boolean  $useStreams  True to use streams
+     * @param   string   $src             The name of the php (temporary) uploaded file
+     * @param   string   $dest            The path (including filename) to move the uploaded file to
+     * @param   boolean  $useStreams      True to use streams
+     * @param   boolean  $allowUnsafe     Allow the upload of unsafe files
+     * @param   array    $safeFileOptions Options to InputFilter::isSafeFile
      *
      * @return  boolean  True on success
      *
-     * @since   1.0
      * @throws  FilesystemException
+     *@since   1.0
      */
-    public static function upload($src, $dest, $useStreams = false)
+    public static function upload($src, $dest, $useStreams = false, $allowUnsafe = false, $safeFileOptions = [])
     {
+        if (!$allowUnsafe) {
+            $descriptor = [
+                'tmp_name' => $src,
+                'name'     => basename($dest),
+                'type'     => '',
+                'error'    => '',
+                'size'     => '',
+            ];
+
+            $isSafe = static::isSafeFile($descriptor, $safeFileOptions);
+
+            if (!$isSafe) {
+                throw new FilesystemException(__METHOD__ . ': File not uploaded for security reasons!');
+            }
+        }
+
         // Ensure that the path is valid and clean
         $dest = Path::clean($dest);
 
@@ -384,5 +413,263 @@ class File
     public static function exists(string $file): bool
     {
         return is_file(Path::clean($file));
+    }
+
+    /**
+     * Checks an uploaded for suspicious naming and potential PHP contents which could indicate a hacking attempt.
+     *
+     * The options you can define are:
+     * null_byte                   Prevent files with a null byte in their name (buffer overflow attack)
+     * forbidden_extensions        Do not allow these strings anywhere in the file's extension
+     * php_tag_in_content          Do not allow `<?php` tag in content
+     * phar_stub_in_content        Do not allow the `__HALT_COMPILER()` phar stub in content
+     * shorttag_in_content         Do not allow short tag `<?` in content
+     * shorttag_extensions         Which file extensions to scan for short tags in content
+     * fobidden_ext_in_content     Do not allow forbidden_extensions anywhere in content
+     * php_ext_content_extensions  Which file extensions to scan for .php in content
+     *
+     * This code is an adaptation and improvement of Admin Tools' UploadShield feature,
+     * relicensed and contributed by its author.
+     *
+     * @param   array  $file     An uploaded file descriptor
+     * @param   array  $options  The scanner options (see the code for details)
+     *
+     * @return  boolean  True of the file is safe
+     *
+     * @since   3.3.0
+     */
+    public static function isSafeFile($file, $options = [])
+    {
+        $defaultOptions = [
+
+            // Null byte in file name
+            'null_byte' => true,
+
+            // Forbidden string in extension (e.g. php matched .php, .xxx.php, .php.xxx and so on)
+            'forbidden_extensions' => self::FORBIDDEN_FILE_EXTENSIONS,
+
+            // <?php tag in file contents
+            'php_tag_in_content' => true,
+
+            // <? tag in file contents
+            'shorttag_in_content' => true,
+
+            // __HALT_COMPILER()
+            'phar_stub_in_content' => true,
+
+            // Which file extensions to scan for short tags
+            'shorttag_extensions' => [
+                'inc', 'phps', 'class', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8', 'txt', 'dat', 'tpl', 'tmpl',
+            ],
+
+            // Forbidden extensions anywhere in the content
+            'fobidden_ext_in_content' => true,
+
+            // Which file extensions to scan for .php in the content
+            'php_ext_content_extensions' => ['zip', 'rar', 'tar', 'gz', 'tgz', 'bz2', 'tbz', 'jpa'],
+        ];
+
+        $options = array_merge($defaultOptions, $options);
+
+        // Make sure we can scan nested file descriptors
+        $descriptors = $file;
+
+        if (isset($file['name'], $file['tmp_name'])) {
+            $descriptors = static::decodeFileData(
+                [
+                    $file['name'],
+                    $file['type'],
+                    $file['tmp_name'],
+                    $file['error'],
+                    $file['size'],
+                ]
+            );
+        }
+
+        // Handle non-nested descriptors (single files)
+        if (isset($descriptors['name'])) {
+            $descriptors = [$descriptors];
+        }
+
+        // Scan all descriptors detected
+        foreach ($descriptors as $fileDescriptor) {
+            if (!isset($fileDescriptor['name'])) {
+                // This is a nested descriptor. We have to recurse.
+                if (!static::isSafeFile($fileDescriptor, $options)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            $tempNames     = $fileDescriptor['tmp_name'];
+            $intendedNames = $fileDescriptor['name'];
+
+            if (!\is_array($tempNames)) {
+                $tempNames = [$tempNames];
+            }
+
+            if (!\is_array($intendedNames)) {
+                $intendedNames = [$intendedNames];
+            }
+
+            $len = \count($tempNames);
+
+            for ($i = 0; $i < $len; $i++) {
+                $tempName     = array_shift($tempNames);
+                $intendedName = array_shift($intendedNames);
+
+                // 1. Null byte check
+                if ($options['null_byte']) {
+                    if (strstr($intendedName, "\x00")) {
+                        return false;
+                    }
+                }
+
+                // 2. PHP-in-extension check (.php, .php.xxx[.yyy[.zzz[...]]], .xxx[.yyy[.zzz[...]]].php)
+                if (!empty($options['forbidden_extensions'])) {
+                    $explodedName = explode('.', $intendedName);
+                    $explodedName = array_reverse($explodedName);
+                    array_pop($explodedName);
+                    $explodedName = array_map('strtolower', $explodedName);
+
+                    /*
+                     * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
+                     * be set, i.e. they should have unique values.
+                     */
+                    foreach ($options['forbidden_extensions'] as $ext) {
+                        if (\in_array($ext, $explodedName)) {
+                            return false;
+                        }
+                    }
+                }
+
+                // 3. File contents scanner (PHP tag in file contents)
+                if (
+                    $options['php_tag_in_content']
+                    || $options['shorttag_in_content'] || $options['phar_stub_in_content']
+                    || ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions']))
+                ) {
+                    $fp = \strlen($tempName) ? @fopen($tempName, 'r') : false;
+
+                    if ($fp !== false) {
+                        $data = '';
+
+                        while (!feof($fp)) {
+                            $data .= @fread($fp, 131072);
+
+                            if ($options['php_tag_in_content'] && stripos($data, '<?php') !== false) {
+                                return false;
+                            }
+
+                            if ($options['phar_stub_in_content'] && stripos($data, '__HALT_COMPILER()') !== false) {
+                                return false;
+                            }
+
+                            if ($options['shorttag_in_content']) {
+                                $suspiciousExtensions = $options['shorttag_extensions'];
+
+                                if (empty($suspiciousExtensions)) {
+                                    $suspiciousExtensions = [
+                                        'inc', 'phps', 'class', 'php3', 'php4', 'txt', 'dat', 'tpl', 'tmpl',
+                                    ];
+                                }
+
+                                /*
+                                 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
+                                 * be set, i.e. they should have unique values.
+                                 */
+                                $collide = false;
+
+                                foreach ($suspiciousExtensions as $ext) {
+                                    if (\in_array($ext, $explodedName)) {
+                                        $collide = true;
+
+                                        break;
+                                    }
+                                }
+
+                                if ($collide) {
+                                    // These are suspicious text files which may have the short tag (<?) in them
+                                    if (strstr($data, '<?')) {
+                                        return false;
+                                    }
+                                }
+                            }
+
+                            if ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions'])) {
+                                $suspiciousExtensions = $options['php_ext_content_extensions'];
+
+                                if (empty($suspiciousExtensions)) {
+                                    $suspiciousExtensions = [
+                                        'zip', 'rar', 'tar', 'gz', 'tgz', 'bz2', 'tbz', 'jpa',
+                                    ];
+                                }
+
+                                /*
+                                 * DO NOT USE array_intersect HERE! array_intersect expects the two arrays to
+                                 * be set, i.e. they should have unique values.
+                                 */
+                                $collide = false;
+
+                                foreach ($suspiciousExtensions as $ext) {
+                                    if (\in_array($ext, $explodedName)) {
+                                        $collide = true;
+
+                                        break;
+                                    }
+                                }
+
+                                if ($collide) {
+                                    /*
+                                     * These are suspicious text files which may have an executable
+                                     * file extension in them
+                                     */
+                                    foreach ($options['forbidden_extensions'] as $ext) {
+                                        if (strstr($data, '.' . $ext)) {
+                                            return false;
+                                        }
+                                    }
+                                }
+                            }
+
+                            /*
+                             * This makes sure that we don't accidentally skip a <?php tag if it's across
+                             * a read boundary, even on multibyte strings
+                             */
+                            $data = substr($data, -10);
+                        }
+
+                        fclose($fp);
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Method to decode a file data array.
+     *
+     * @param   array  $data  The data array to decode.
+     *
+     * @return  array
+     *
+     * @since   3.3.0
+     */
+    protected static function decodeFileData(array $data)
+    {
+        $result = [];
+
+        if (\is_array($data[0])) {
+            foreach ($data[0] as $k => $v) {
+                $result[$k] = static::decodeFileData([$data[0][$k], $data[1][$k], $data[2][$k], $data[3][$k], $data[4][$k]]);
+            }
+
+            return $result;
+        }
+
+        return ['name' => $data[0], 'type' => $data[1], 'tmp_name' => $data[2], 'error' => $data[3], 'size' => $data[4]];
     }
 }


### PR DESCRIPTION
### Summary of Changes
This PR returns the "old" hardening behavior of the CMS File::upload method

### Testing Instructions
Code review, compare with original code of the CMS package.
