### PR TITLE
Use jpath_root constant as check fallback

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -150,6 +150,11 @@ class Path
      */
     public static function check($path, $basePath = '')
     {
+        // If a JPATH_ROOT constant is defined, it's used as fallback basePath
+        if ($basePath == '' && defined('JPATH_ROOT')) {
+            $basePath = JPATH_ROOT;
+        }
+
         if (strpos($path, '..') !== false) {
             throw new FilesystemException(
                 sprintf(


### PR DESCRIPTION
### Summary of Changes
This PR returns the "old" behavior of the check method to ensure that JPATH_ROOT is used a basedir fallback for the check method

### Testing Instructions
Code review, compare with original code of the CMS package.
